### PR TITLE
Fix trace level

### DIFF
--- a/MeadowCLI/Properties/launchSettings.json
+++ b/MeadowCLI/Properties/launchSettings.json
@@ -1,7 +1,0 @@
-{
-  "profiles": {
-    "Meadow.CLI": {
-      "commandName": "Project"
-    }
-  }
-}


### PR DESCRIPTION
Fixed bug that prevented Meadow.CLI from allowing TraceLevel 0, which reset the trace level to default.