### PR TITLE
Fix for Bug57

### DIFF
--- a/Meadow.CLI.Core/Internals/MeadowComms/HostComBuffer.cs
+++ b/Meadow.CLI.Core/Internals/MeadowComms/HostComBuffer.cs
@@ -44,11 +44,6 @@ namespace MeadowCLI.Hcom
             head = bottom;
             tail = bottom;
 
-            for (int i = 0; i < hcomCircularBuffer.Length; i++)
-            {
-                hcomCircularBuffer[i] = 0xff;
-            }
-
             return HcomBufferReturn.HCOM_CIR_BUF_INIT_OK;
         }
 
@@ -136,8 +131,6 @@ namespace MeadowCLI.Hcom
                         return HcomBufferReturn.HCOM_CIR_BUF_GET_BUF_NO_ROOM;
 
                     Array.Copy(hcomCircularBuffer, tail, packetBuffer, 0, sizeFoundTop);
-
-                    // memcpy(packetBuffer, tail, sizeFoundTop);
                     tail = foundOffset + 1;
                     packetLength = sizeFoundTop;
                     return HcomBufferReturn.HCOM_CIR_BUF_GET_FOUND_MSG;

--- a/Meadow.CLI.Core/Internals/MeadowComms/MeadowSerialDataProcessor.cs
+++ b/Meadow.CLI.Core/Internals/MeadowComms/MeadowSerialDataProcessor.cs
@@ -206,6 +206,10 @@ namespace MeadowCLI.Hcom
                 {
                     // The buffer to receive the message is too small! Perhaps 
                     // corrupted data in buffer.
+                    // I don't know why but without the following 2 lines the Debug.Assert will
+                    // assert eventhough the following line is not executed?
+                    Console.WriteLine($"Need a buffer with {packetLength} bytes, not {MeadowDeviceManager.MaxSizeOfXmitPacket}");
+                    Thread.Sleep(1000);
                     Debug.Assert(false);
                 }
 


### PR DESCRIPTION
CLI modified to expect, more or less a stream from Meadow code Console.WriteLine and Console.Write methods. The code checks for 0x0a (line feed) which is how Console.WriteLine ends strings. The 0x0a is replaced with Environment.NewLine so that both Mac and Windows have their expected New Line.