### PR TITLE
MeadowCLI: Migrate TargetFramework to netcoreapp3.1

### DIFF
--- a/Meadow.CLI.Core/Meadow.CLI.Core.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Meadow.CLI</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.8.1</Version>
@@ -26,6 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
+    <PackageReference Include="System.IO.Ports" Version="4.7.0" />
+    <PackageReference Include="System.Management" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MeadowCLI/Meadow.CLI.csproj
+++ b/MeadowCLI/Meadow.CLI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />


### PR DESCRIPTION
Migrating the project from `net472` to `netcoreapp3.1` so that we can create CLI distributions for different architectures using a single executable file using the `dotnet` core CLI:

```
dotnet publish -r linux-x64 --self-contained true /p:PublishSingleFile=true
dotnet publish -r linux-arm --self-contained true /p:PublishSingleFile=true
dotnet publish -r linux-arm64 --self-contained true /p:PublishSingleFile=true
dotnet publish -r win-x64 --self-contained true /p:PublishSingleFile=true
dotnet publish -r osx-x64 --self-contained true /p:PublishSingleFile=true
```

I only tested the binaries generated for the `linux-x64` and `win-x64`