### PR TITLE
Update assembly manager to skip unavaliable references

### DIFF
--- a/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
@@ -42,6 +42,13 @@ namespace MeadowCLI.DeviceManagement
             }
 
             Collection<AssemblyNameReference> references;
+
+            if(File.Exists(fileName) == false)
+            {
+                Console.WriteLine($"Could not find {fileName}");
+                return null;
+            }
+
             using (var definition = AssemblyDefinition.ReadAssembly(fileName))
             {
                 references = definition.MainModule.AssemblyReferences;
@@ -55,9 +62,16 @@ namespace MeadowCLI.DeviceManagement
             {
                 if (!dependencyMap.Contains(ar.Name))
                 {
+                    var namedRefs = GetAssemblyNameReferences(ar.Name, folderPath);
+
+                    if(namedRefs == null)
+                    {
+                        continue;
+                    }
+
                     dependencyMap.Add(ar.Name);
 
-                    GetDependencies(GetAssemblyNameReferences(ar.Name, folderPath), dependencyMap);
+                    GetDependencies(namedRefs, dependencyMap);
                 }
             }
 


### PR DESCRIPTION
If a dll isn't on the local dev machine, it will fail silently - for APIs not available, the app will throw an exception 

This will fix F# apps (which aren't working with the latest assembly crawling changes) and enable VB.NET