### PR TITLE
Replace string.contains with proper error check.

### DIFF
--- a/Meadow.CLI.Core/Internals/Dfu/DfuUtils.cs
+++ b/Meadow.CLI.Core/Internals/Dfu/DfuUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -221,15 +222,21 @@ namespace Meadow.CLI.Core.Internals.Dfu
                     return string.Empty;
                 }
             }
-            catch (Exception ex)
+            catch (Win32Exception ex)
             {
-                if (ex.Message.Contains("cannot find") || ex.Message.Contains("No such file or directory"))
+                switch (ex.NativeErrorCode)
                 {
-                    return string.Empty;
-                }
-                else
-                {
-                    throw ex;
+                    case 0x0002: // ERROR_FILE_NOT_FOUND
+                    case 0x0003: // ERROR_PATH_NOT_FOUND
+                    case 0x000F: // ERROR_INVALID_DRIVE
+                    case 0x0014: // ERROR_BAD_UNIT
+                    case 0x001B: // ERROR_SECTOR_NOT_FOUND
+                    case 0x0033: // ERROR_REM_NOT_LIST
+                    case 0x013D: // ERROR_MR_MID_NOT_FOUND
+                        return string.Empty;
+                    
+                    default:
+                        throw;
                 }
             }
         }


### PR DESCRIPTION
By removing the `string.Contains` check, and replacing it with a check on the property `NativeErrorCode`, this update allows non-english operating systems to run `meadow flash os` successfully.