### PR TITLE
Use downloaded BCL to override a project's local assemblies.

### DIFF
--- a/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
@@ -13,7 +13,7 @@ namespace Meadow.CLI.Core.DeviceManagement
         private static readonly List<string> dependencyMap = new List<string>();
         private static string? fileName;
 
-        private static readonly string meadow_override_path = Path.Combine(DownloadManager.FirmwareDownloadsFilePath, "bcl");
+        private static readonly string meadow_override_path = Path.Combine(DownloadManager.FirmwareDownloadsFilePath, "meadow_assemblies");
 
         public static List<string> GetDependencies(string file, string path)
         {

--- a/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Mono.Cecil;
 using Mono.Collections.Generic;
+using System;
 
 namespace Meadow.CLI.Core.DeviceManagement
 {
@@ -10,66 +11,66 @@ namespace Meadow.CLI.Core.DeviceManagement
     public static class AssemblyManager
     {
         private static readonly List<string> dependencyMap = new List<string>();
-        private static string? folderPath;
         private static string? fileName;
+
+        private static readonly string meadow_override_path = Path.Combine(DownloadManager.FirmwareDownloadsFilePath, "bcl");
 
         public static List<string> GetDependencies(string file, string path)
         {
+            if (!Directory.Exists(meadow_override_path))
+                throw new Exception ("OS download not found. Please run the 'download os' command");
+
             dependencyMap.Clear();
 
-            var refs = GetAssemblyNameReferences(fileName = file, folderPath = path);
+            var refs = GetAssemblyNameReferences(fileName = file, path);
 
-            var dependencies = GetDependencies(refs, dependencyMap);
+            var dependencies = GetDependencies(refs, dependencyMap, path);
 
-            for (int i = 0; i < dependencies.Count; i++)
-            {
-                dependencies[i] += ".dll";
-            }
             return dependencies;
         }
 
-        static Collection<AssemblyNameReference> GetAssemblyNameReferences(string fileName, string? path = null)
+        static (Collection<AssemblyNameReference>?, string?) GetAssemblyNameReferences(string fileName, string path)
         {
-            if (!string.IsNullOrWhiteSpace(path))
+            string? ResolvePath (string fileName, string path)
             {
-                fileName = Path.Combine(path!, fileName);
+                string attempted_path = Path.Combine(path, fileName);
+                if (Path.GetExtension(fileName) != ".exe" &&
+                    Path.GetExtension(fileName) != ".dll")
+                {
+                    attempted_path += ".dll";
+                }
+                return File.Exists(attempted_path) ? attempted_path : null;
             }
 
-            if (Path.GetExtension(fileName) != ".exe" &&
-                Path.GetExtension(fileName) != ".dll")
-            {
-                fileName += ".dll";
-            }
+            string? resolved_path = ResolvePath (fileName, meadow_override_path) ?? ResolvePath (fileName, path);
+
+            if (resolved_path is null)
+                return (null, null);
 
             Collection<AssemblyNameReference> references;
 
-            if(File.Exists(fileName) == false)
-            {
-                return null;
-            }
-
-            using (var definition = AssemblyDefinition.ReadAssembly(fileName))
+            using (var definition = AssemblyDefinition.ReadAssembly(resolved_path))
             {
                 references = definition.MainModule.AssemblyReferences;
             }
-            return references;
+            return (references, resolved_path);
         }
 
-        static List<string> GetDependencies(Collection<AssemblyNameReference> references, List<string> dependencyMap)
+        static List<string> GetDependencies((Collection<AssemblyNameReference>?, string?) references, List<string> dependencyMap, string folderPath)
         {
-            foreach (var ar in references)
+            if (dependencyMap.Contains(references.Item2))
+                return dependencyMap;
+
+            dependencyMap.Add(references.Item2);
+
+            foreach (var ar in references.Item1)
             {
-                if (!dependencyMap.Contains(ar.Name))
-                {
-                    var namedRefs = GetAssemblyNameReferences(ar.Name, folderPath);
+                var namedRefs = GetAssemblyNameReferences(ar.Name, folderPath);
 
-                    if (namedRefs == null)
-                        continue;
+                if (namedRefs.Item1 == null)
+                    continue;
 
-                    dependencyMap.Add(ar.Name);
-
-                    GetDependencies(namedRefs, dependencyMap);
-                }
+                GetDependencies(namedRefs, dependencyMap, folderPath);
             }
 
             return dependencyMap;

--- a/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
@@ -13,12 +13,13 @@ namespace Meadow.CLI.Core.DeviceManagement
         private static readonly List<string> dependencyMap = new List<string>();
         private static string? fileName;
 
-        private static readonly string meadow_override_path = Path.Combine(DownloadManager.FirmwareDownloadsFilePath, "meadow_assemblies");
+        private static string meadow_override_path = null;
 
-        public static List<string> GetDependencies(string file, string path)
+        public static List<string> GetDependencies(string file, string path, string osVersion)
         {
+            meadow_override_path = Path.Combine(DownloadManager.FirmwareDownloadsFilePath, osVersion, "meadow_assemblies");
             if (!Directory.Exists(meadow_override_path))
-                throw new Exception ("OS download not found. Please run the 'download os' command");
+                throw new Exception ($"OS download for version {osVersion} not found.");
 
             dependencyMap.Clear();
 

--- a/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
@@ -19,7 +19,7 @@ namespace Meadow.CLI.Core.DeviceManagement
         {
             meadow_override_path = Path.Combine(DownloadManager.FirmwareDownloadsFilePath, osVersion, "meadow_assemblies");
             if (!Directory.Exists(meadow_override_path))
-                throw new Exception ($"OS download for version {osVersion} not found.");
+                meadow_override_path = path;
 
             dependencyMap.Clear();
 

--- a/Meadow.CLI.Core/Devices/IMeadowDevice.cs
+++ b/Meadow.CLI.Core/Devices/IMeadowDevice.cs
@@ -47,7 +47,7 @@ namespace Meadow.CLI.Core.Devices
         public Task QspiWriteAsync(int value, CancellationToken cancellationToken = default);
         public Task QspiReadAsync(int value, CancellationToken cancellationToken = default);
         public Task QspiInitAsync(int value, CancellationToken cancellationToken = default);
-        public Task DeployAppAsync(string fileName, bool includePdbs = false, CancellationToken cancellationToken = default);
+        public Task DeployAppAsync(string fileName, string osVersion, bool includePdbs = false, CancellationToken cancellationToken = default);
         public Task ForwardVisualStudioDataToMonoAsync(byte[] debuggerData, uint userData, CancellationToken cancellationToken = default);
         public Task StartDebuggingAsync(int port, CancellationToken cancellationToken);
         public Task<string?> GetInitialBytesFromFile(string fileName, uint partition = 0, CancellationToken cancellationToken = default);

--- a/Meadow.CLI.Core/Devices/MeadowDeviceHelper.cs
+++ b/Meadow.CLI.Core/Devices/MeadowDeviceHelper.cs
@@ -260,7 +260,11 @@ namespace Meadow.CLI.Core.Devices
             await MonoDisableAsync(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
-            await _meadowDevice.DeployAppAsync(fileName, includePdbs, cancellationToken).ConfigureAwait(false);
+            //check the device OS version, in order to download matching assemblies to it
+            var deviceInfo = await _meadowDevice.GetDeviceInfoAsync(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+            string osVersion = deviceInfo.MeadowOsVersion.Split(' ')[0]; // we want the first part of e.g. '0.5.3.0 (Oct 13 2021 13:39:12)'
+
+            await _meadowDevice.DeployAppAsync(fileName, osVersion, includePdbs, cancellationToken).ConfigureAwait(false);
 
             await MonoEnableAsync(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);

--- a/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
+++ b/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
@@ -504,9 +504,11 @@ namespace Meadow.CLI.Core.Devices
         }
 
         public async Task DeployAppAsync(string applicationFilePath,
+                                        string osVersion,
                                          bool includePdbs = false,
                                          CancellationToken cancellationToken = default)
         {
+
             if (!File.Exists(applicationFilePath))
             {
                 Console.WriteLine($"{applicationFilePath} not found.");
@@ -581,7 +583,7 @@ namespace Meadow.CLI.Core.Devices
                 }
             }
 
-            var dependencies = AssemblyManager.GetDependencies(fi.Name, fi.DirectoryName);
+            var dependencies = AssemblyManager.GetDependencies(fi.Name, fi.DirectoryName, osVersion);
 
             //crawl dependencies
             foreach (var file in dependencies)
@@ -617,7 +619,7 @@ namespace Meadow.CLI.Core.Devices
                     continue;
                 }
 
-                if (!File.Exists(Path.Combine(fi.DirectoryName, filename)))
+                if (!File.Exists(file.Key))
                 {
                     Logger.LogInformation("{file} not found", filename);
                     continue;

--- a/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
+++ b/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
@@ -571,8 +571,7 @@ namespace Meadow.CLI.Core.Devices
                 var crc = CrcTools.Crc32part(bytes, len, 0); // 0x04C11DB7);
 
                 Logger.LogDebug("{file} crc is {crc:X8}", file, crc);
-                files.Add(Path.GetFileName(file), crc);
-
+                files.Add(file, crc);
                 if (includePdbs)
                 {
                     var pdbFile = Path.ChangeExtension(file, "pdb");
@@ -582,51 +581,52 @@ namespace Meadow.CLI.Core.Devices
                 }
             }
 
-            foreach (var file in paths)
-            {
-                await AddFile(file, includePdbs)
-                    .ConfigureAwait(false);
-            }
-
             var dependencies = AssemblyManager.GetDependencies(fi.Name, fi.DirectoryName);
 
             //crawl dependencies
             foreach (var file in dependencies)
             {
-                await AddFile(Path.Combine(fi.DirectoryName, file), includePdbs);
+                await AddFile(file, includePdbs);
             }
 
             // delete unused files
-            foreach (var file in deviceFiles.Keys)
+            foreach (var devicefile in deviceFiles.Keys)
             {
-                if (files.ContainsKey(file) == false)
+                bool found = false;
+                foreach (var localfile in files.Keys)
                 {
-                    await DeleteFileAsync(file, cancellationToken: cancellationToken)
+                    if (Path.GetFileName(localfile).Equals(devicefile))
+                        found = true;
+                }
+                if (!found)
+                {
+                    await DeleteFileAsync(devicefile, cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
 
-                    Logger.LogInformation("Removing file: {file}", file);
+                    Logger.LogInformation("Removing file: {file}", devicefile);
                 }
             }
 
             // write new files
             foreach (var file in files)
             {
-                if (deviceFiles.ContainsKey(file.Key) && deviceFiles[file.Key] == file.Value)
+                var filename = Path.GetFileName(file.Key);
+                if (deviceFiles.ContainsKey(filename) && deviceFiles[filename] == file.Value)
                 {
-                    Logger.LogInformation("Skipping file (hash match): {file}", file.Key);
+                    Logger.LogInformation("Skipping file (hash match): {file}", filename);
                     continue;
                 }
 
-                if (!File.Exists(Path.Combine(fi.DirectoryName, file.Key)))
+                if (!File.Exists(Path.Combine(fi.DirectoryName, filename)))
                 {
-                    Logger.LogInformation("{file} not found", file.Key);
+                    Logger.LogInformation("{file} not found", filename);
                     continue;
                 }
 
-                Logger.LogInformation("Writing file: {file}", file.Key);
+                Logger.LogInformation("Writing file: {file}", filename);
                 await WriteFileAsync(
-                        Path.Combine(fi.DirectoryName, file.Key),
                         file.Key,
+                        filename,
                         DefaultTimeout,
                         cancellationToken)
                     .ConfigureAwait(false);

--- a/Meadow.CLI.Core/DownloadManager.cs
+++ b/Meadow.CLI.Core/DownloadManager.cs
@@ -16,10 +16,8 @@ namespace Meadow.CLI.Core
 {
     public class DownloadManager
     {
-        readonly string _versionCheckUrl =
-            "https://s3-us-west-2.amazonaws.com/downloads.wildernesslabs.co/Meadow_Beta/latest.json";
-
-        string VersionCheckFile => new Uri(_versionCheckUrl).Segments.Last();
+        readonly string _versionCheckUrlRoot =
+            "https://s3-us-west-2.amazonaws.com/downloads.wildernesslabs.co/Meadow_Beta/";
 
         public static readonly string FirmwareDownloadsFilePath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
@@ -51,9 +49,18 @@ namespace Meadow.CLI.Core
             _logger = loggerFactory.CreateLogger<DownloadManager>();
         }
 
-        public async Task DownloadLatestAsync()
+        public async Task DownloadLatestAsync(string? version = null)
         {
-            _logger.LogInformation("Downloading latest version file");
+            string _versionCheckUrl = null;
+            if (version is null) {
+                _logger.LogInformation("Downloading latest version file");
+                _versionCheckUrl = _versionCheckUrlRoot + "latest.json";
+            }
+            else {
+                _logger.LogInformation("Download version file for release " + version);
+                _versionCheckUrl = _versionCheckUrlRoot + version + ".json";
+            }
+            string VersionCheckFile = new Uri(_versionCheckUrl).Segments.Last();
             var versionCheckFile = await DownloadFileAsync(new Uri(_versionCheckUrl));
 
             var payload = File.ReadAllText(versionCheckFile);
@@ -77,21 +84,29 @@ namespace Meadow.CLI.Core
                 return;
             }
 
-            if (Directory.Exists(FirmwareDownloadsFilePath))
+            if (!Directory.Exists(FirmwareDownloadsFilePath))
             {
-                CleanPath(FirmwareDownloadsFilePath);
+                Directory.CreateDirectory(FirmwareDownloadsFilePath);
             }
 
-            Directory.CreateDirectory(FirmwareDownloadsFilePath);
+            var local_path = Path.Combine(FirmwareDownloadsFilePath, release.Version);
+
+            if (Directory.Exists(local_path))
+            {
+                     _logger.LogInformation( $"OS version {release.Version}  is already installed." );
+                     return;
+            }
+
+            Directory.CreateDirectory(local_path);
 
             _logger.LogInformation("Downloading latest MCU firmware");
-            await DownloadAndExtractFileAsync(new Uri(release.DownloadURL));
+            await DownloadAndExtractFileAsync(new Uri(release.DownloadURL), local_path);
 
             _logger.LogInformation("Downloading latest ESP32 firmware");
-            await DownloadAndExtractFileAsync(new Uri(release.NetworkDownloadURL));
+            await DownloadAndExtractFileAsync(new Uri(release.NetworkDownloadURL), local_path);
 
             _logger.LogInformation(
-                $"Downloaded and extracted OS version {release.Version} to: {FirmwareDownloadsFilePath}");
+                $"Downloaded and extracted OS version {release.Version} to: {local_path}");
         }
 
         public async Task InstallDfuUtilAsync(bool is64Bit = true,
@@ -224,14 +239,14 @@ namespace Meadow.CLI.Core
             return downloadFileName;
         }
 
-        private async Task DownloadAndExtractFileAsync(Uri uri, CancellationToken cancellationToken = default)
+        private async Task DownloadAndExtractFileAsync(Uri uri, string target_path, CancellationToken cancellationToken = default)
         {
             var downloadFileName = await DownloadFileAsync(uri, cancellationToken).ConfigureAwait(false);
 
-            _logger.LogDebug("Extracting firmware to {path}", FirmwareDownloadsFilePath);
+            _logger.LogDebug("Extracting firmware to {path}", target_path);
             ZipFile.ExtractToDirectory(
                 downloadFileName,
-                FirmwareDownloadsFilePath);
+                target_path);
             try
             {
                 File.Delete(downloadFileName);

--- a/Meadow.CLI.Core/DownloadManager.cs
+++ b/Meadow.CLI.Core/DownloadManager.cs
@@ -76,6 +76,13 @@ namespace Meadow.CLI.Core
                                      .GetCustomAttribute<AssemblyFileVersionAttribute>()
                                      .Version;
 
+            if (release.Version.ToVersion() < "0.6.0.0".ToVersion())
+            {
+                _logger.LogInformation(
+                    $"Installing OS version {release.Version} is not supported by this tool anymore. The minimum version supported is 0.6.0.0.");
+                return;
+            }
+
             if (release.MinCLIVersion.ToVersion() > appVersion.ToVersion())
             {
                 _logger.LogInformation(

--- a/Meadow.CLI.Core/DownloadManager.cs
+++ b/Meadow.CLI.Core/DownloadManager.cs
@@ -49,7 +49,7 @@ namespace Meadow.CLI.Core
             _logger = loggerFactory.CreateLogger<DownloadManager>();
         }
 
-        public async Task DownloadLatestAsync(string? version = null)
+        public async Task DownloadLatestAsync(string? version = null, bool force = false)
         {
             string _versionCheckUrl = null;
             if (version is null) {
@@ -93,8 +93,12 @@ namespace Meadow.CLI.Core
 
             if (Directory.Exists(local_path))
             {
-                     _logger.LogInformation( $"OS version {release.Version}  is already installed." );
+                if (force)
+                    CleanPath(local_path);
+                else {
+                     _logger.LogInformation( $"OS version {release.Version} is already installed." );
                      return;
+                }
             }
 
             Directory.CreateDirectory(local_path);

--- a/Meadow.CLI/Commands/App/DeployAppCommand.cs
+++ b/Meadow.CLI/Commands/App/DeployAppCommand.cs
@@ -4,6 +4,7 @@ using CliFx.Infrastructure;
 using Meadow.CLI.Core;
 using Meadow.CLI.Core.DeviceManagement;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Meadow.CLI.Commands.App
 {
@@ -30,7 +31,11 @@ namespace Meadow.CLI.Commands.App
             await base.ExecuteAsync(console);
             var cancellationToken = console.RegisterCancellationHandler();
 
-            await DownloadManager.DownloadLatestAsync().ConfigureAwait(false);
+            //check the device OS version, in order to download matching assemblies to it
+            var deviceInfo = await Meadow.GetDeviceInfoAsync(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+            string osVersion = deviceInfo.MeadowOsVersion.Split(' ')[0]; // we want the first part of e.g. '0.5.3.0 (Oct 13 2021 13:39:12)'
+
+            await new DownloadManager(LoggerFactory).DownloadLatestAsync(osVersion).ConfigureAwait(false);
 
             await Meadow.DeployAppAsync(File, IncludePdbs, cancellationToken)
                         .ConfigureAwait(false);

--- a/Meadow.CLI/Commands/App/DeployAppCommand.cs
+++ b/Meadow.CLI/Commands/App/DeployAppCommand.cs
@@ -30,6 +30,8 @@ namespace Meadow.CLI.Commands.App
             await base.ExecuteAsync(console);
             var cancellationToken = console.RegisterCancellationHandler();
 
+            await DownloadManager.DownloadLatestAsync().ConfigureAwait(false);
+
             await Meadow.DeployAppAsync(File, IncludePdbs, cancellationToken)
                         .ConfigureAwait(false);
         }

--- a/Meadow.CLI/Commands/Utility/DownloadOsCommand.cs
+++ b/Meadow.CLI/Commands/Utility/DownloadOsCommand.cs
@@ -16,12 +16,15 @@ namespace Meadow.CLI.Commands.Utility
             _logger = loggerFactory.CreateLogger<InstallDfuUtilCommand>();
         }
 
+        [CommandOption("force", 'f', Description = "Force re-download of the OS", IsRequired = false)]
+        public bool force { get; init; } = false;
+
         public override async ValueTask ExecuteAsync(IConsole console)
         {
             var cancellationToken = console.RegisterCancellationHandler();
             await base.ExecuteAsync(console);
 
-            await DownloadManager.DownloadLatestAsync().ConfigureAwait(false);
+            await DownloadManager.DownloadLatestAsync(null, force).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
For all libraries in our downloaded BCL bundle, choose to deploy those to Meadow overriding any other assembly binaries in nugets and the bin/ directory