### PR TITLE
Update MeadowLocalDeviceComms.cs to set timeout to 60sec (vs default 30s)

### DIFF
--- a/Meadow.CLI.Core/Devices/MeadowLocalDeviceComms.cs
+++ b/Meadow.CLI.Core/Devices/MeadowLocalDeviceComms.cs
@@ -122,6 +122,7 @@ namespace Meadow.CLI.Core.Devices
                     HcomMeadowRequestType.HCOM_MDOW_REQUEST_MONO_UPDATE_RUNTIME =>
                         new SimpleCommandBuilder(HcomMeadowRequestType.HCOM_MDOW_REQUEST_MONO_UPDATE_FILE_END)
                             .WithUserData(lastInSeries ? 1U : 0U)
+                            .WithTimeout(TimeSpan.FromSeconds(60))
                             .Build(),
                     HcomMeadowRequestType.HCOM_MDOW_REQUEST_START_ESP_FILE_TRANSFER =>
                         new SimpleCommandBuilder(HcomMeadowRequestType.HCOM_MDOW_REQUEST_END_ESP_FILE_TRANSFER)


### PR DESCRIPTION
Fix/workaround for https://github.com/WildernessLabs/Meadow_Issues/issues/175