### PR TITLE
Update MeadowDeviceManager.cs to only detect serial ports starting with COM

### DIFF
--- a/Meadow.CLI.Core/DeviceManagement/MeadowDeviceManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/MeadowDeviceManager.cs
@@ -294,6 +294,10 @@ namespace Meadow.CLI.Core.DeviceManagement
             {
                 var port = line.Substring(line.IndexOf('(') + 1, line.IndexOf(')') - line.IndexOf('(') - 1);
                 var serialNumber = line.Substring(line.LastIndexOf('\\') + 1);
+                
+                if (!port.StartsWith("COM"))
+                    continue;
+
                 logger.LogDebug("Found Meadow at {port} with SerialNumber {serialNumber}", port, serialNumber);
                 ports.Add(new MeadowDeviceEntity(port, serialNumber));
             }


### PR DESCRIPTION
Proposed fix/workaround for https://github.com/WildernessLabs/Meadow.CLI/issues/95