### PR TITLE
Replace `wmic` tooling for `GetSerialPortsWindows()` with PowerShell equivalent

### DIFF
--- a/Meadow.CLI.Core/DeviceManagement/MeadowDeviceManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/MeadowDeviceManager.cs
@@ -320,7 +320,7 @@ namespace Meadow.CLI.Core.DeviceManagement
 
                 ProcessStartInfo psi = new()
                 {
-                    FileName = "pwsh.exe",
+                    FileName = "powershell.exe",
                     Arguments = $"-NoLogo -NoProfile -NonInteractive -Command {queryArgument}",
                     UseShellExecute = false,
                     RedirectStandardOutput = true,


### PR DESCRIPTION
Reverts be318543c6d65e00772067bd07177d496065cedd, and replaces `wmic`… based tooling with PowerShell equivalent.

As noted in #100 by @adrianstevens, it seems Microsoft is deprecating the `wmic` tool, and pointing users towards using the PowerShell cmdlets. This replaces the invocation of `wmic` in `GetMeadowSerialPortsForWindows()` with an invocation of the cmdlet `Get-CmiInstance` (aliased `gcmi`).

The end result of this is the same as the `wmic` tooling, but hopefully should be supported by Microsoft/Windows going forward.

`gcmi` shipped with Powershell 3.0 in 2012, so it is available by default on all platforms Windows 8 and newer. As before, any failure in invoking the cmdlet will result in falling back to the `GetSerialPorts()` method.