### PR TITLE
Update erase flash version check logic

### DIFF
--- a/Meadow.CLI/Commands/DeviceManagement/FlashOsCommand.cs
+++ b/Meadow.CLI/Commands/DeviceManagement/FlashOsCommand.cs
@@ -89,11 +89,13 @@ namespace Meadow.CLI.Commands.DeviceManagement
 
             Meadow = new MeadowDeviceHelper(meadow, Logger);
 
-            // Get Current Device Version
-            var currentOsVersion = new Version(Meadow.DeviceInfo?.MeadowOsVersion.Split(' ')[0]);
+            // Get Previous OS Version
+            // We just flashed the OS so it will show the current version 
+            // But the runtime hasn't been updated yet so should match the previous OS version
+            var previousOsVersion = new Version(Meadow.DeviceInfo?.MonoVersion.Split(' ')[0]);
 
             // If less that B6.1 flash
-            if (currentOsVersion.CompareTo(new Version(MINIMUM_OS_VERSION)) < 0) {
+            if (previousOsVersion.CompareTo(new Version(MINIMUM_OS_VERSION)) < 0) {
                 // Ask User 1st before wiping
                 Logger.LogInformation($"Your OS version is older than {MINIMUM_OS_VERSION}. A bulk flash erase is required.");
                 var yesOrNo = "y";


### PR DESCRIPTION
Fix for erase flash logic 

Compare to the mono version instead of the OS version since the OS version will reflect whatever has just been written to Meadow (i.e. we want the previous version not the current version)