### PR TITLE
Remove logic to automatically use local runtime for flash os

### DIFF
--- a/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
+++ b/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
@@ -210,35 +210,23 @@ namespace Meadow.CLI.Core.Devices
                                                  CancellationToken cancellationToken = default)
         {
             var sourceFilename = fileName;
+            
             if (string.IsNullOrWhiteSpace(sourceFilename))
             {
-                // check local override
                 sourceFilename = Path.Combine(
-                    Directory.GetCurrentDirectory(),
+                    DownloadManager.FirmwareDownloadsFilePath,
                     DownloadManager.RuntimeFilename);
 
                 if (File.Exists(sourceFilename))
                 {
-                    Logger.LogWarning(
-                        $"*** OVERRIDE: USING CURRENT DIRECTORY FOR '{DownloadManager.RuntimeFilename}'");
+                    Logger.LogInformation("FileName not specified, using latest download.");
                 }
                 else
                 {
-                    sourceFilename = Path.Combine(
-                        DownloadManager.FirmwareDownloadsFilePath,
-                        DownloadManager.RuntimeFilename);
+                    Logger.LogInformation(
+                        "Unable to locate a runtime file. Either provide a path or download one.");
 
-                    if (File.Exists(sourceFilename))
-                    {
-                        Logger.LogInformation("FileName not specified, using latest download.");
-                    }
-                    else
-                    {
-                        Logger.LogInformation(
-                            "Unable to locate a runtime file. Either provide a path or download one.");
-
-                        return; // KeepConsoleOpen?
-                    }
+                    return; // KeepConsoleOpen?
                 }
             }
 

--- a/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
+++ b/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
@@ -209,7 +209,7 @@ namespace Meadow.CLI.Core.Devices
                                                  uint partition = 0,
                                                  CancellationToken cancellationToken = default)
         {
-            var sourceFilename = fileName;
+            string sourceFilename = fileName ?? string.Empty;
             
             if (string.IsNullOrWhiteSpace(sourceFilename))
             {
@@ -223,14 +223,12 @@ namespace Meadow.CLI.Core.Devices
                 }
                 else
                 {
-                    Logger.LogInformation(
-                        "Unable to locate a runtime file. Either provide a path or download one.");
+                    Logger.LogInformation("Unable to locate a runtime file. Either provide a path or download one.");
 
-                    return; // KeepConsoleOpen?
+                    return;
                 }
             }
-
-            if (!File.Exists(sourceFilename))
+            else if (!File.Exists(sourceFilename))
             {
                 sourceFilename = Path.Combine(Directory.GetCurrentDirectory(), sourceFilename);
 

--- a/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
+++ b/Meadow.CLI.Core/Devices/MeadowLocalDeviceFileManager.cs
@@ -232,8 +232,13 @@ namespace Meadow.CLI.Core.Devices
 
             if (!File.Exists(sourceFilename))
             {
-                Logger.LogInformation($"File '{sourceFilename}' not found");
-                return;
+                sourceFilename = Path.Combine(Directory.GetCurrentDirectory(), sourceFilename);
+
+                if (!File.Exists(sourceFilename))
+                {
+                    Logger.LogInformation($"File '{sourceFilename}' not found");
+                    return;
+                }
             }
 
             var targetFileName = Path.GetFileName(sourceFilename);


### PR DESCRIPTION
This standardizes and simplifies - and this logic has been confusing for a couple of reasons:

1. we don't have comparable logic for the OS binary so it was only automatically using the runtime binary
2. we have explicit command line arguments to use local binaries for flash os


