### PR TITLE
Fix NuGet URL casing

### DIFF
--- a/Meadow.CLI.Core/DownloadManager.cs
+++ b/Meadow.CLI.Core/DownloadManager.cs
@@ -238,7 +238,7 @@ namespace Meadow.CLI.Core
                                          .Version;
 
                 var json = await Client.GetStringAsync(
-                               $"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json");
+                               $"https://api.nuget.org/v3-flatcontainer/{packageId.ToLower()}/index.json");
 
                 var result = JsonSerializer.Deserialize<PackageVersions>(json);
 


### PR DESCRIPTION
Warning: I haven't tested this!

This fix appears to correct the 404 request from #163. NuGet appears to want the package ID to be all lowercase. I haven't built the tool or tested how it behaves with the correct URL in place, though.

It's possible that other code that wasn't previously run before with the 404 exception will now run with different, untested issues.