### PR TITLE
Changes to log MessageType.ErrOutput as errors. Useful for when the p…

### DIFF
--- a/Meadow.CLI.Core/Devices/MeadowLocalDevice.Comms.cs
+++ b/Meadow.CLI.Core/Devices/MeadowLocalDevice.Comms.cs
@@ -318,10 +318,22 @@ namespace Meadow.CLI.Core.Devices
 
             void ResponseHandler(object s, MeadowMessageEventArgs e)
             {
-                Logger?.LogTrace(
-                    "Received MessageType: {messageType} Message: {message}",
-                    e.MessageType,
-                    string.IsNullOrWhiteSpace(e.Message) ? "[empty]" : e.Message);
+
+                var msg = string.IsNullOrWhiteSpace(e.Message) ? "[empty]" : e.Message;
+
+                switch (e.MessageType)
+                {
+                    case MeadowMessageType.Data:
+                        Logger?.LogInformation(msg); // We may not need this
+                        break;
+                    case MeadowMessageType.ErrOutput:
+                        Logger?.LogError(msg);
+                        break;
+                    default:
+                        break;
+                }
+
+                Logger?.LogTrace($"Received MessageType: {e.MessageType} Message: {msg}");
 
                 if (command.ResponsePredicate(e))
                 {

--- a/Meadow.CLI.Core/Internals/MeadowCommunication/MeadowSerialDataProcessor.cs
+++ b/Meadow.CLI.Core/Internals/MeadowCommunication/MeadowSerialDataProcessor.cs
@@ -301,7 +301,7 @@ namespace Meadow.CLI.Core.Internals.MeadowCommunication
                             OnReceiveData?.Invoke(this, new MeadowMessageEventArgs(MeadowMessageType.Concluded));
                             break;
                         case HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_ERROR:
-                            OnReceiveData?.Invoke(this, new MeadowMessageEventArgs(MeadowMessageType.Data, responseString));
+                            OnReceiveData?.Invoke(this, new MeadowMessageEventArgs(MeadowMessageType.ErrOutput, responseString));
                             break;
                         case HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_INFORMATION:
                             foreach (var m in FormatForOutput(StdInfoPrefix, responseString))

--- a/Meadow.CLI/Commands/Utility/ListenCommand.cs
+++ b/Meadow.CLI/Commands/Utility/ListenCommand.cs
@@ -28,8 +28,19 @@ namespace Meadow.CLI.Commands.Utility
             _logger.LogInformation("Listening for Meadow Console output. Press Ctrl+C to exit");
             void ResponseHandler(object s, MeadowMessageEventArgs e)
             {
-                if (e.MessageType == MeadowMessageType.Data)
-                    _logger.LogInformation(e.Message);
+                var msg = string.IsNullOrWhiteSpace(e.Message) ? "[empty]" : e.Message;
+
+                switch (e.MessageType)
+                {
+                    case MeadowMessageType.Data:
+                        _logger?.LogInformation(msg); // We may not need this
+                        break;
+                    case MeadowMessageType.ErrOutput:
+                        _logger?.LogError(msg);
+                        break;
+                    default:
+                        break;
+                }
             };
             Meadow.MeadowDevice.DataProcessor.OnReceiveData += ResponseHandler;
             try


### PR DESCRIPTION
…rotocol version changes.

Now when there is a protocol version mismatch we should see an error similar to...
`Meadow is expecting a newer CLI Protocol version. Please update Meadow.CLI. (version received::0006 required:0007).`