### PR TITLE
Unify Tools Releases

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -275,8 +275,8 @@ jobs:
         name: Meadow.Mac.2019.mpack
         path: 'vs-mac/VS4Mac_Meadow_Extension/bin/Release/net472/*.mpack'
   
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      name: Get Commit Messages
+    # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    - name: Get Commit Messages
       id: commit_messages
       uses: actions/github-script@v4
       env:
@@ -291,8 +291,8 @@ jobs:
           const messages = commits.map(commit => `- ${commit.commit.message}`).join('\n');
           return messages;
 
-    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      name: Create VS2019 Release
+    # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    - name: Create VS2019 Release
       id: create_release
       uses: actions/create-release@v1
       env:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,7 @@
 name: Meadow.CLI
 env:
-  RELEASE_VERSION: 0.97.0
+  TOOLS_RELEASE_VERSION: 0.97.0
+  MEADOW_OS_VERSION: 0.9.6.3
 
 on:
   push:
@@ -33,33 +34,33 @@ jobs:
       name: Update CLI Version Numbers
       run: |
         $content = Get-Content main/Meadow.CLI/Meadow.CLI.csproj | Out-String
-        $newcontent = $content -replace '<PackageVersion>.*</PackageVersion>', '<PackageVersion>${{ ENV.RELEASE_VERSION }}</PackageVersion>'
+        $newcontent = $content -replace '<PackageVersion>.*</PackageVersion>', '<PackageVersion>${{ ENV.TOOLS_RELEASE_VERSION }}</PackageVersion>'
         $newcontent | Set-Content main/Meadow.CLI/Meadow.CLI.csproj
 
         $content = Get-Content main/Meadow.CLI.Core/Meadow.CLI.Core.csproj | Out-String
-        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.RELEASE_VERSION }}</Version>'
+        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.TOOLS_RELEASE_VERSION }}</Version>'
         $newcontent | Set-Content main/Meadow.CLI.Core/Meadow.CLI.Core.csproj
 
         $content = Get-Content main/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj | Out-String
-        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.RELEASE_VERSION }}</Version>'
+        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.TOOLS_RELEASE_VERSION }}</Version>'
         $newcontent | Set-Content main/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
 
         $content = Get-Content main/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj | Out-String
-        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.RELEASE_VERSION }}</Version>'
+        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.TOOLS_RELEASE_VERSION }}</Version>'
         $newcontent | Set-Content main/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
 
         $content = Get-Content main/Meadow.CLI.Core/Constants.cs | Out-String
-        $newcontent = $content -replace 'CLI_VERSION = \".*\";', 'CLI_VERSION = "${{ ENV.RELEASE_VERSION }}";'
+        $newcontent = $content -replace 'CLI_VERSION = \".*\";', 'CLI_VERSION = "${{ ENV.TOOLS_RELEASE_VERSION }}";'
         $newcontent | Set-Content main/Meadow.CLI.Core/Constants.cs
 
     - name: Add MSBuild to Path
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Restore dependencies
-      run: dotnet restore main/MeadowCLI.sln
+      run: dotnet restore main/MeadowCLI.sln /p:Configuration=Release
 
     - name: Build
-      run: msbuild main/MeadowCLI.sln /t:Rebuild /p:Configuration=Release
+      run: dotnet build main/MeadowCLI.sln /p:Configuration=Release
 
     - name: Upload nuget Artifacts for internal testing
       uses: actions/upload-artifact@v2
@@ -117,15 +118,15 @@ jobs:
       name: Update VS2019 Version Numbers
       run: |
         $content = Get-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2019/source.extension.vsixmanifest | Out-String
-        $newcontent = $content -replace 'Version="0.*" Language="en-US" Publisher="Wilderness Labs"', 'Version="${{ ENV.RELEASE_VERSION }}" Language="en-US" Publisher="Wilderness Labs"'
+        $newcontent = $content -replace 'Version="0.*" Language="en-US" Publisher="Wilderness Labs"', 'Version="${{ ENV.TOOLS_RELEASE_VERSION }}" Language="en-US" Publisher="Wilderness Labs"'
         $newcontent | Set-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2019/source.extension.vsixmanifest
 
     - name: Restore VS2019 dependencies
-      run: msbuild vs-win/VS_Meadow_Extension.2019.sln /t:Restore /p:Configuration=Release
+      run: dotnet restore vs-win/VS_Meadow_Extension.2019.sln /p:Configuration=Release
 
     - name: Build VS2019 Extension
       id: VS2019-Extension
-      run: msbuild vs-win/VS_Meadow_Extension.2019.sln /t:Rebuild /p:Configuration=Release
+      run: msbuild vs-win/VS_Meadow_Extension.2019.sln  /t:Rebuild /p:Configuration=Release
       env:
         DevEnvDir: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE'
 
@@ -186,11 +187,11 @@ jobs:
       name: Update VS2022 Version Numbers
       run: |
         $content = Get-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2022/source.extension.vsixmanifest | Out-String
-        $newcontent = $content -replace 'Version="0.*" Language="en-US" Publisher="Wilderness Labs"', 'Version="${{ ENV.RELEASE_VERSION }}" Language="en-US" Publisher="Wilderness Labs"'
+        $newcontent = $content -replace 'Version="0.*" Language="en-US" Publisher="Wilderness Labs"', 'Version="${{ ENV.TOOLS_RELEASE_VERSION }}" Language="en-US" Publisher="Wilderness Labs"'
         $newcontent | Set-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2022/source.extension.vsixmanifest
 
     - name: Restore VS2022 dependencies
-      run: dotnet restore vs-win/VS_Meadow_Extension.2022.sln
+      run: dotnet restore vs-win/VS_Meadow_Extension.2022.sln /p:Configuration=Release
 
     - name: Build VS2022 Extension
       run: msbuild vs-win/VS_Meadow_Extension.2022.sln  /t:Rebuild /p:Configuration=Release
@@ -259,7 +260,7 @@ jobs:
     - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       name: Update VS2019 Version Numbers
       run: |
-        sed -i "" "s/Version = \"0.*\"/Version = \"${{ENV.RELEASE_VERSION}}\"/" vs-mac/VS4Mac_Meadow_Extension/Properties/AddinInfo.cs
+        sed -i "" "s/Version = \"0.*\"/Version = \"${{ENV.TOOLS_RELEASE_VERSION}}\"/" vs-mac/VS4Mac_Meadow_Extension/Properties/AddinInfo.cs
 
     - name: Restore our VS2019 project
       run: |
@@ -274,25 +275,34 @@ jobs:
       with:
         name: Meadow.Mac.2019.mpack
         path: 'vs-mac/VS4Mac_Meadow_Extension/bin/Release/net472/*.mpack'
-  
-    # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    - name: Get Commit Messages
-      id: commit_messages
-      uses: actions/github-script@v4
-      env:
-        GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
-      with:
-        script: |
-          const commits = await github.repos.listCommits({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: github.context.payload.release.target_commitish
-          });
-          const messages = commits.map(commit => `- ${commit.commit.message}`).join('\n');
-          return messages;
 
-    # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    - name: Create VS2019 Release
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Get Commit Messages
+      id: commit_messages
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.MEADOW_MAC_TOKEN }}
+        script: |
+          const { owner, repo } = context.repo;
+
+          const latestRelease = await github.rest.repos.getLatestRelease({
+            owner: 'WildernessLabs',
+            repo: 'VS_Mac_Meadow_Extension',
+          });
+
+          const commits = await github.rest.repos.listCommits({
+            owner: 'WildernessLabs',
+            repo: 'VS_Mac_Meadow_Extension',
+            since: latestRelease.created_at
+          });
+
+          const messages = commits.data.map(commit => `- ${commit.commit.message}`).join('  \n');
+          const formattedMessages = `**Release Notes:**  \n${messages}`;
+
+          return formattedMessages;
+
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Create VS2019 Release
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -300,11 +310,13 @@ jobs:
       with:
         owner: WildernessLabs
         repo: VS_Mac_Meadow_Extension
-        tag_name: VS2019 v${{ ENV.RELEASE_VERSION }}
-        release_name: VS2019 v${{ ENV.RELEASE_VERSION }}
-        body: ${{ steps.commit_messages.outputs.result }}
+        tag_name: v${{ ENV.TOOLS_RELEASE_VERSION }}.VS2019 
+        release_name: VS Mac VS2019 Extension v${{ ENV.TOOLS_RELEASE_VERSION }} for Meadow OS v${{ ENV.MEADOW_OS_VERSION }}
+        body: | 
+          ${{ steps.commit_messages.outputs.result }}
         draft: true
         prerelease: false
+        commitish: main
   
     # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     #- name: Upload Release Asset
@@ -356,7 +368,7 @@ jobs:
     - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       name: Update VS2022 Version Numbers
       run: |
-        sed -i "" "s/Version = \"0.*\"/Version = \"${{ ENV.RELEASE_VERSION }}\"/" vs-mac/VS4Mac_Meadow_Extension/Properties/AddinInfo.2022.cs
+        sed -i "" "s/Version = \"0.*\"/Version = \"${{ ENV.TOOLS_RELEASE_VERSION }}\"/" vs-mac/VS4Mac_Meadow_Extension/Properties/AddinInfo.2022.cs
 
     - name: Restore our VS2022 project
       run: |
@@ -375,18 +387,27 @@ jobs:
     - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       name: Get Commit Messages
       id: commit_messages
-      uses: actions/github-script@v4
-      env:
-        GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
+      uses: actions/github-script@v6
       with:
+        github-token: ${{ secrets.MEADOW_MAC_TOKEN }}
         script: |
-          const commits = await github.repos.listCommits({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            sha: github.context.payload.release.target_commitish
+          const { owner, repo } = context.repo;
+
+          const latestRelease = await github.rest.repos.getLatestRelease({
+            owner: 'WildernessLabs',
+            repo: 'VS_Mac_Meadow_Extension',
           });
-          const messages = commits.map(commit => `- ${commit.commit.message}`).join('\n');
-          return messages;
+
+          const commits = await github.rest.repos.listCommits({
+            owner: 'WildernessLabs',
+            repo: 'VS_Mac_Meadow_Extension',
+            since: latestRelease.created_at
+          });
+
+          const messages = commits.data.map(commit => `- ${commit.commit.message}`).join('  \n');
+          const formattedMessages = `**Release Notes:**  \n${messages}`;
+          
+          return formattedMessages;
 
     - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       name: Create VS2022 Release
@@ -397,11 +418,13 @@ jobs:
       with:
         owner: WildernessLabs
         repo: VS_Mac_Meadow_Extension
-        tag_name: VS2022 v${{ ENV.RELEASE_VERSION }}
-        release_name: VS2022 v${{ ENV.RELEASE_VERSION }}
-        body: ${{ steps.commit_messages.outputs.result }}
+        tag_name: v${{ ENV.TOOLS_RELEASE_VERSION }}.VS2022
+        release_name: VS Mac VS2022 Extension v${{ ENV.TOOLS_RELEASE_VERSION }} for Meadow OS v${{ ENV.MEADOW_OS_VERSION }}
+        body: | 
+          ${{ steps.commit_messages.outputs.result }}
         draft: true
         prerelease: false
+        commitish: main
 
     # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     #- name: Upload Release Asset
@@ -474,7 +497,7 @@ jobs:
       name: Update VSCode Version Numbers
       run: |
         $content = Get-Content vs-code/package.json | Out-String
-        $newcontent = $content -replace '"version": "0.*",', '"version": "${{ENV.RELEASE_VERSION}}",'
+        $newcontent = $content -replace '"version": "0.*",', '"version": "${{ENV.TOOLS_RELEASE_VERSION}}",'
         $newcontent | Set-Content vs-code/package.json
 
     - name: Restore VSCode Extension dependencies

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: Meadow.CLI
+env:
+  RELEASE_VERSION: 0.97.0
 
 on:
   push:
@@ -7,8 +9,72 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  build-and-optionally-publish-nuget:
+    runs-on: windows-latest
+    name: Build and Optionally Publish Meadow.CLI nuget
+      
+    steps:
+    - name: Checkout Meadow.CLI.Core side-by-side
+      uses: actions/checkout@v2
+      with:
+        path: main
+
+    - name: Setup .NET Core SDK 6.0.x & 7.0.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1.0.5
+
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Update CLI Version Numbers
+      run: |
+        $content = Get-Content main/Meadow.CLI/Meadow.CLI.csproj | Out-String
+        $newcontent = $content -replace '<PackageVersion>.*</PackageVersion>', '<PackageVersion>${{ ENV.RELEASE_VERSION }}</PackageVersion>'
+        $newcontent | Set-Content main/Meadow.CLI/Meadow.CLI.csproj
+
+        $content = Get-Content main/Meadow.CLI.Core/Meadow.CLI.Core.csproj | Out-String
+        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.RELEASE_VERSION }}</Version>'
+        $newcontent | Set-Content main/Meadow.CLI.Core/Meadow.CLI.Core.csproj
+
+        $content = Get-Content main/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj | Out-String
+        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.RELEASE_VERSION }}</Version>'
+        $newcontent | Set-Content main/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
+
+        $content = Get-Content main/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj | Out-String
+        $newcontent = $content -replace '<Version>.*</Version>', '<Version>${{ ENV.RELEASE_VERSION }}</Version>'
+        $newcontent | Set-Content main/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
+
+        $content = Get-Content main/Meadow.CLI.Core/Constants.cs | Out-String
+        $newcontent = $content -replace 'CLI_VERSION = \".*\";', 'CLI_VERSION = "${{ ENV.RELEASE_VERSION }}";'
+        $newcontent | Set-Content main/Meadow.CLI.Core/Constants.cs
+
+    - name: Add MSBuild to Path
+      uses: microsoft/setup-msbuild@v1.1
+
+    - name: Restore dependencies
+      run: dotnet restore main/MeadowCLI.sln
+
+    - name: Build
+      run: msbuild main/MeadowCLI.sln /t:Rebuild /p:Configuration=Release
+
+    - name: Upload nuget Artifacts for internal testing
+      uses: actions/upload-artifact@v2
+      with:
+        name: Meadow.CLI.nuget
+        path: 'main\**\Meadow.CLI\bin\Release\*.nupkg'
+
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Publish Meadow.CLI Nuget publically
+      run: |
+        nuget push main\**\Meadow.CLI\bin\Release\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+
   build-vswin-2019:
     runs-on: windows-2019
+    needs: [build-and-optionally-publish-nuget]
     name: Build Win 2019 Extension
 
     steps:
@@ -23,9 +89,8 @@ jobs:
       with:
         repository: WildernessLabs/VS_Win_Meadow_Extension
         path: vs-win
-        ref: develop
 
-    - name: Setup .NET Core SDK 6.0.x & 7.0.x
+    - name: Setup .NET Core SDK 5.0.x, 6.0.x & 7.0.x
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
@@ -36,19 +101,39 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-    - name: Restore dependencies
-      run: dotnet restore vs-win/VS_Meadow_Extension.2019.sln
-
     - name: Add MSBuild to Path
       uses: microsoft/setup-msbuild@v1.1
 
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Update VS2019 Version Numbers
+      run: |
+        $content = Get-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2019/source.extension.vsixmanifest | Out-String
+        $newcontent = $content -replace 'Version="0.*" Language="en-US" Publisher="Wilderness Labs"', 'Version="${{ ENV.RELEASE_VERSION }}" Language="en-US" Publisher="Wilderness Labs"'
+        $newcontent | Set-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2019/source.extension.vsixmanifest
+
+    - name: Restore VS2019 dependencies
+      run: msbuild vs-win/VS_Meadow_Extension.2019.sln /t:Restore /p:Configuration=Release
+
     - name: Build VS2019 Extension
-      run: msbuild vs-win/VS_Meadow_Extension.2019.sln  /t:Rebuild /p:Configuration=Release
+      id: VS2019-Extension
+      run: msbuild vs-win/VS_Meadow_Extension.2019.sln /t:Rebuild /p:Configuration=Release
       env:
         DevEnvDir: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE'
 
+    - name: Upload VS2019 VSIX Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Meadow.Win.VS2019.vsix
+        path: 'vs-win\VS_Meadow_Extension\VS_Meadow_Extension.2019\bin\Release\*.vsix'
+        
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Publish VS2019 Extension
+      run: |
+          & "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" publish -payload "main\VS_Meadow_Extension\VS_Meadow_Extension.2019\bin\Release\Meadow.2019.vsix" -publishManifest "main\publishManifest.2019.json" -ignoreWarnings "None" -personalAccessToken "${{ secrets.MARKETPLACE_PUBLISH_PAT }}"
+
   build-vswin-2022:
     runs-on: windows-2022
+    needs: [build-and-optionally-publish-nuget]
     name: Build Win 2022 Extension
 
     steps:
@@ -63,7 +148,6 @@ jobs:
       with:
         repository: WildernessLabs/VS_Win_Meadow_Extension
         path: vs-win
-        ref: develop
 
     - name: Setup .NET Core SDK 6.0.x & 7.0.x
       uses: actions/setup-dotnet@v1
@@ -75,21 +159,40 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-    - name: Restore dependencies
-      run: dotnet restore vs-win/VS_Meadow_Extension.2022.sln
-
     - name: Add MSBuild to Path
       uses: microsoft/setup-msbuild@v1.1
       with:
         vs-version: '[17.0, 18.0)'
 
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Update VS2022 Version Numbers
+      run: |
+        $content = Get-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2022/source.extension.vsixmanifest | Out-String
+        $newcontent = $content -replace 'Version="0.*" Language="en-US" Publisher="Wilderness Labs"', 'Version="${{ ENV.RELEASE_VERSION }}" Language="en-US" Publisher="Wilderness Labs"'
+        $newcontent | Set-Content vs-win/VS_Meadow_Extension/VS_Meadow_Extension.2022/source.extension.vsixmanifest
+
+    - name: Restore VS2022 dependencies
+      run: dotnet restore vs-win/VS_Meadow_Extension.2022.sln
+
     - name: Build VS2022 Extension
       run: msbuild vs-win/VS_Meadow_Extension.2022.sln  /t:Rebuild /p:Configuration=Release
       env:
         DevEnvDir: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE'
+        
+    - name: Upload VS2022 VSIX Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Meadow.Win.VS2022.vsix
+        path: 'vs-win\VS_Meadow_Extension\VS_Meadow_Extension.2022\bin\Release\*.vsix'
+          
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Publish VS2022 Extension
+      run: |
+          & "${env:ProgramFiles}\Microsoft Visual Studio\2022\Enterprise\VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" publish -payload "main\VS_Meadow_Extension\VS_Meadow_Extension.2022\bin\Release\Meadow.2022.vsix" -publishManifest "main\publishManifest.2022.json" -ignoreWarnings "None" -personalAccessToken "${{ secrets.MARKETPLACE_PUBLISH_PAT }}"
 
   build-vsmac-2019:
     name: Build Mac 2019 Extension
+    needs: [build-and-optionally-publish-nuget]
     runs-on: macos-11
 
     steps:
@@ -103,7 +206,6 @@ jobs:
       with:
         repository: WildernessLabs/VS_Mac_Meadow_Extension
         path: vs-mac
-        ref: develop
 
     - name: Set default Xcode 13.0
       run: |
@@ -111,29 +213,86 @@ jobs:
         echo "MD_APPLE_SDK_ROOT=$XCODE_ROOT" >> $GITHUB_ENV
         sudo xcode-select -s $XCODE_ROOT
 
-    - name: Setup .NET Core SDK 6.0.x & 7.0.x
+    - name: Setup .NET Core SDK 5.0.x, 6.0.x & 7.0.x
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: |
+          5.0.x
           6.0.x
           7.0.x
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-    - name: Restore dependencies
-      run: dotnet restore vs-mac/VS4Mac_Meadow_Extension.sln
-
     - name: Work around so that VS2019 is picked up.
       run: |
         mv "/Applications/Visual Studio.app" "/Applications/Visual Studio 2022.app"
         mv "/Applications/Visual Studio 2019.app" "/Applications/Visual Studio.app"
 
-    - name: Build
-      run: msbuild vs-mac/VS4Mac_Meadow_Extension.sln /t:Rebuild /p:Configuration=Release
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Update VS2019 Version Numbers
+      run: |
+        sed -i "" "s/Version = \"0.*\"/Version = \"${{ENV.RELEASE_VERSION}}\"/" vs-mac/VS4Mac_Meadow_Extension/Properties/AddinInfo.cs
+
+    - name: Restore our VS2019 project
+      run: |
+        msbuild vs-mac/VS4Mac_Meadow_Extension.sln /t:Restore /p:Configuration=Release
+
+    - name: Build and Package the VS2019 Extension
+      run: |
+        msbuild vs-mac/VS4Mac_Meadow_Extension.sln /t:Build /p:Configuration=Release /p:CreatePackage=true
+
+    - name: Upload Mac VS2019 mpack Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Meadow.Mac.2019.mpack
+        path: 'vs-mac/VS4Mac_Meadow_Extension/bin/Release/net472/*.mpack'
+  
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Get Commit Messages
+      id: commit_messages
+      uses: actions/github-script@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
+      with:
+        script: |
+          const commits = await github.repos.listCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: github.context.payload.release.target_commitish
+          });
+          const messages = commits.map(commit => `- ${commit.commit.message}`).join('\n');
+          return messages;
+
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Create VS2019 Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
+      with:
+        owner: WildernessLabs
+        repo: VS_Mac_Meadow_Extension
+        tag_name: VS2019 v${{ ENV.RELEASE_VERSION }}
+        release_name: VS2019 v${{ ENV.RELEASE_VERSION }}
+        body: ${{ steps.commit_messages.outputs.result }}
+        draft: true
+        prerelease: false
+  
+    # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    #- name: Upload Release Asset
+    #  uses: actions/upload-release-asset@v1.0.2
+    #  env:
+    #    GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
+    #  with:
+    #    upload_url: ${{ steps.create_release.outputs.upload_url }}
+    #    asset_path: vs-mac/VS4Mac_Meadow_Extension/bin/Release/net472/*.mpack
+    #    asset_name: Meadow.Mac.2019.mpack
+    #    asset_content_type: application/zip
 
   build-vsmac-2022:
     name: Build Mac 2022 Extension
+    needs: [build-and-optionally-publish-nuget]
     runs-on: macos-12
 
     steps:
@@ -147,7 +306,6 @@ jobs:
       with:
         repository: WildernessLabs/VS_Mac_Meadow_Extension
         path: vs-mac
-        ref: develop
 
     - name: Setup .NET Core SDK 6.0.x & 7.0.x
       uses: actions/setup-dotnet@v1
@@ -159,14 +317,70 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-    - name: Restore dependencies
-      run: dotnet restore vs-mac/VS4Mac_Meadow_Extension_2022.sln
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Update VS2022 Version Numbers
+      run: |
+        sed -i "" "s/Version = \"0.*\"/Version = \"${{ ENV.RELEASE_VERSION }}\"/" vs-mac/VS4Mac_Meadow_Extension/Properties/AddinInfo.2022.cs
 
-    - name: Build
-      run: dotnet msbuild vs-mac/VS4Mac_Meadow_Extension_2022.sln /t:Rebuild /p:Configuration=Release
+    - name: Restore our VS2022 project
+      run: |
+        dotnet msbuild vs-mac/VS4Mac_Meadow_Extension/Meadow.Sdks.IdeExtensions.Vs4Mac.2022.csproj /t:Restore /p:Configuration=Release
+
+    - name: Build and Package the VS2022 Extension
+      run: |
+        dotnet msbuild vs-mac/VS4Mac_Meadow_Extension/Meadow.Sdks.IdeExtensions.Vs4Mac.2022.csproj /t:Build /p:Configuration=Release /p:CreatePackage=true
+    
+    - name: Upload VS2022 mpack Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Meadow.Mac.2022.mpack
+        path: 'vs-mac/VS4Mac_Meadow_Extension/bin/Release/net7.0/*.mpack'
+
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Get Commit Messages
+      id: commit_messages
+      uses: actions/github-script@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
+      with:
+        script: |
+          const commits = await github.repos.listCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            sha: github.context.payload.release.target_commitish
+          });
+          const messages = commits.map(commit => `- ${commit.commit.message}`).join('\n');
+          return messages;
+
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Create VS2022 Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
+      with:
+        owner: WildernessLabs
+        repo: VS_Mac_Meadow_Extension
+        tag_name: VS2022 v${{ ENV.RELEASE_VERSION }}
+        release_name: VS2022 v${{ ENV.RELEASE_VERSION }}
+        body: ${{ steps.commit_messages.outputs.result }}
+        draft: true
+        prerelease: false
+
+    # - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    #- name: Upload Release Asset
+    #  uses: actions/upload-release-asset@v1.0.2
+    #  env:
+    #    GITHUB_TOKEN: ${{ secrets.MEADOW_MAC_TOKEN }}
+    #  with:
+    #    upload_url: ${{ steps.create_release.outputs.upload_url }}
+    #    asset_path: vs-mac/VS4Mac_Meadow_Extension/bin/Release/net7.0/*.mpack
+    #    asset_name: Meadow.Mac.2022.mpack
+    #    asset_content_type: application/zip
 
   build-vscode:
     runs-on: windows-latest
+    needs: [build-and-optionally-publish-nuget]
     name: Build VSCode Extension
 
     steps:
@@ -180,7 +394,6 @@ jobs:
       with:
         repository: WildernessLabs/VSCode_Meadow_Extension
         path: vs-code
-        ref: develop
         submodules: true
 
     - name: Setup .NET Core SDK 6.0.x & 7.0.x
@@ -200,70 +413,58 @@ jobs:
 
     - name: Install NPM
       run: |
+        cd vs-code
         npm install
         npm update
 
     - name: Install vsce
       run: |
-        npm i -g vsce
+        npm i -g @vscode/vsce
 
     - name: Add MSBuild to Path
       uses: microsoft/setup-msbuild@v1.1
 
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Update VSCode Version Numbers
+      run: |
+        $content = Get-Content vs-code/package.json | Out-String
+        $newcontent = $content -replace '"version": "0.*",', '"version": "${{ENV.RELEASE_VERSION}}",'
+        $newcontent | Set-Content vs-code/package.json
+
     - name: Restore VSCode Extension dependencies
-      run: msbuild vs-code/src/csharp/VSCodeMeadow.sln /t:Restore /p:Configuration=Release
+      run: dotnet restore vs-code/src/csharp/VSCodeMeadow.csproj /p:Configuration=Debug
 
     - name: Build VSCode Extension
       id: VSCode-Extension
-      run: msbuild vs-code/src/csharp/VSCodeMeadow.sln /t:Rebuild /p:Configuration=Release
+      run: dotnet build vs-code/src/csharp/VSCodeMeadow.csproj /p:Configuration=Debug
 
-  publish-nuget:
-    runs-on: windows-latest
-    needs: [build-vscode, build-vsmac-2019, build-vsmac-2022, build-vswin-2022, build-vswin-2019]
-    name: Publish Meadow.CLI nuget
-    env:
-      RELEASE_VERSION: 0.97.0
-      
-    steps:
-    - name: Checkout Meadow.CLI.Core side-by-side
-      uses: actions/checkout@v2
-      with:
-        path: main
-
-    - name: Setup .NET Core SDK 6.0.x & 7.0.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: |
-          6.0.x
-          7.0.x
-
-    - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.5
-
-    - name: Update CLI Version Numbers
+    - name: Build WebPack
       run: |
-        sed -i "s/<PackageVersion>.*<\/PackageVersion>/<PackageVersion>${{ENV.RELEASE_VERSION}}<\/PackageVersion>/" main/Meadow.CLI/Meadow.CLI.csproj
-        sed -i "s/<Version>.*<\/Version>/<Version>${{ENV.RELEASE_VERSION}}<\/Version>/" main/Meadow.CLI.Core/Meadow.CLI.Core.csproj
-        sed -i "s/<Version>.*<\/Version>/<Version>${{ENV.RELEASE_VERSION}}<\/Version>/" main/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
-        sed -i "s/<Version>.*<\/Version>/<Version>${{ENV.RELEASE_VERSION}}<\/Version>/" main/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
-        sed -i "s/public const string CLI_VERSION = \".*\"/public const string CLI_VERSION = \"${{ENV.RELEASE_VERSION}}\"/"  main/Meadow.CLI.Core/Constants.cs
+        cd vs-code
+        npm install -g webpack
+        npm install -D ts-loader
+        npm run webpack
 
-    - name: Add MSBuild to Path
-      uses: microsoft/setup-msbuild@v1.1
-
-    - name: Restore dependencies
-      run: msbuild main/MeadowCLI.sln /t:Restore /p:Configuration=Release
-
-    - name: Build
-      run: msbuild main/MeadowCLI.sln /t:Rebuild /p:Configuration=Release
-
-    - name: Upload nuget Artifacts for internal testing
-      uses: actions/upload-artifact@v2
-      with:
-        name: Meadow.CLI.nuget
-        path: 'main/**/*.nupkg'
+    - if: ${{ github.ref != 'refs/heads/main' }}
+      name: Build Pre-Release VSIX on non main branch
+      run: |
+        cd vs-code
+        vsce package --pre-release
 
     - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      name: Publish VSCode Extension publically
+      name: Build Release VSIX on main branch
       run: |
-        nuget push **\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+        cd vs-code
+        vsce package
+
+    - name: Upload VSIX Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: Meadow.VSCode.vsix
+        path: 'vs-code/*.vsix'
+
+    - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      name: Publish VSCode Extension
+      run: |
+        cd main
+        vsce publish -p ${{ secrets.MARKETPLACE_PUBLISH_PAT }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -221,6 +221,8 @@ jobs:
     runs-on: windows-latest
     needs: [build-vscode, build-vsmac-2019, build-vsmac-2022, build-vswin-2022, build-vswin-2019]
     name: Publish Meadow.CLI nuget
+    env:
+      RELEASE_VERSION: 0.97.0
       
     steps:
     - name: Checkout Meadow.CLI.Core side-by-side
@@ -238,11 +240,19 @@ jobs:
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v1.0.5
 
-    - name: Restore dependencies
-      run: dotnet restore main/MeadowCLI.sln
+    - name: Update CLI Version Numbers
+      run: |
+        sed -i "s/<PackageVersion>.*<\/PackageVersion>/<PackageVersion>${{ENV.RELEASE_VERSION}}<\/PackageVersion>/" main/Meadow.CLI/Meadow.CLI.csproj
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ENV.RELEASE_VERSION}}<\/Version>/" main/Meadow.CLI.Core/Meadow.CLI.Core.csproj
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ENV.RELEASE_VERSION}}<\/Version>/" main/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
+        sed -i "s/<Version>.*<\/Version>/<Version>${{ENV.RELEASE_VERSION}}<\/Version>/" main/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
+        sed -i "s/public const string CLI_VERSION = \".*\"/public const string CLI_VERSION = \"${{ENV.RELEASE_VERSION}}\"/"  main/Meadow.CLI.Core/Constants.cs
 
     - name: Add MSBuild to Path
       uses: microsoft/setup-msbuild@v1.1
+
+    - name: Restore dependencies
+      run: msbuild main/MeadowCLI.sln /t:Restore /p:Configuration=Release
 
     - name: Build
       run: msbuild main/MeadowCLI.sln /t:Rebuild /p:Configuration=Release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -296,8 +296,8 @@ jobs:
             since: latestRelease.created_at
           });
 
-          const messages = commits.data.map(commit => `- ${commit.commit.message}`).join('  \n');
-          const formattedMessages = `**Release Notes:**  \n${messages}`;
+          const messages = commits.data.map(commit => `* ${commit.commit.message}`).join('  \n');
+          const formattedMessages = `## What's Changed  \n${messages}`;
 
           return formattedMessages;
 
@@ -404,8 +404,8 @@ jobs:
             since: latestRelease.created_at
           });
 
-          const messages = commits.data.map(commit => `- ${commit.commit.message}`).join('  \n');
-          const formattedMessages = `**Release Notes:**  \n${messages}`;
+          const messages = commits.data.map(commit => `* ${commit.commit.message}`).join('  \n');
+          const formattedMessages = `## What's Changed  \n${messages}`;
           
           return formattedMessages;
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -84,7 +84,16 @@ jobs:
         repository: WildernessLabs/Meadow.CLI
         path: Meadow.CLI
 
-    - name: Checkout Win Extension side-by-side
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Checkout Win Extension side-by-side
+      uses: actions/checkout@v2
+      with:
+        repository: WildernessLabs/VS_Win_Meadow_Extension
+        path: vs-win
+        ref: main
+
+    - if: ${{ github.ref != 'refs/heads/main' }}
+      name: Checkout Win Extension side-by-side
       uses: actions/checkout@v2
       with:
         repository: WildernessLabs/VS_Win_Meadow_Extension
@@ -143,7 +152,16 @@ jobs:
         repository: WildernessLabs/Meadow.CLI
         path: Meadow.CLI
 
-    - name: Checkout Win Extension side-by-side
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Checkout Win Extension side-by-side
+      uses: actions/checkout@v2
+      with:
+        repository: WildernessLabs/VS_Win_Meadow_Extension
+        path: vs-win
+        ref: main
+
+    - if: ${{ github.ref != 'refs/heads/main' }}
+      name: Checkout Win Extension side-by-side
       uses: actions/checkout@v2
       with:
         repository: WildernessLabs/VS_Win_Meadow_Extension
@@ -201,7 +219,16 @@ jobs:
       with:
         path: Meadow.CLI
 
-    - name: Checkout Mac Extension side-by-side
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Checkout Mac Extension side-by-side
+      uses: actions/checkout@v2
+      with:
+        repository: WildernessLabs/VS_Mac_Meadow_Extension
+        path: vs-mac
+        ref: main
+
+    - if: ${{ github.ref != 'refs/heads/main' }}
+      name: Checkout Mac Extension side-by-side
       uses: actions/checkout@v2
       with:
         repository: WildernessLabs/VS_Mac_Meadow_Extension
@@ -301,7 +328,16 @@ jobs:
       with:
         path: Meadow.CLI
 
-    - name: Checkout Mac Extension side-by-side
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Checkout Mac Extension side-by-side
+      uses: actions/checkout@v2
+      with:
+        repository: WildernessLabs/VS_Mac_Meadow_Extension
+        path: vs-mac
+        ref: main
+
+    - if: ${{ github.ref != 'refs/heads/main' }}
+      name: Checkout Mac Extension side-by-side
       uses: actions/checkout@v2
       with:
         repository: WildernessLabs/VS_Mac_Meadow_Extension
@@ -389,7 +425,17 @@ jobs:
       with:
         path: Meadow.CLI
 
-    - name: Checkout VSCode Extension side-by-side
+    - if: ${{ github.ref == 'refs/heads/main' }}
+      name: Checkout VSCode Extension side-by-side
+      uses: actions/checkout@v2
+      with:
+        repository: WildernessLabs/VSCode_Meadow_Extension
+        path: vs-code
+        submodules: true
+        ref: main
+
+    - if: ${{ github.ref != 'refs/heads/main' }}
+      name: Checkout VSCode Extension side-by-side
       uses: actions/checkout@v2
       with:
         repository: WildernessLabs/VSCode_Meadow_Extension

--- a/Meadow.Tools.code-workspace
+++ b/Meadow.Tools.code-workspace
@@ -1,13 +1,13 @@
 {
 	"folders": [
 		{
-			"path": "."
-		},
-		{
 			"path": "../VS_Mac_Meadow_Extension"
 		},
 		{
 			"path": "../VS_Win_Meadow_Extension"
+		},
+		{
+			"path": "."
 		},
 		{
 			"path": "../VSCode_Meadow_Extension"

--- a/Meadow.Tools.code-workspace
+++ b/Meadow.Tools.code-workspace
@@ -1,0 +1,20 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../VS_Mac_Meadow_Extension"
+		},
+		{
+			"path": "../VS_Win_Meadow_Extension"
+		},
+		{
+			"path": "../VSCode_Meadow_Extension"
+		}
+	],
+	"settings": {
+		"nrf-connect.topdir": "${nrf-connect.sdk:2.2.0}",
+		"nrf-connect.toolchain.path": "${nrf-connect.toolchain:2.2.0}"
+	}
+}


### PR DESCRIPTION
This PR is to try to centralise the tooling release. It will
* Substitute `Meadow.CLI.*`, `VS_Mac`, `VS_Win` and `VSCode` extension version numbers, so they are in sync when we release.
* On push to `main`
  * It will use the value in RELEASE_VERSION value @ https://github.com/WildernessLabs/Meadow.CLI/pull/276/files#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R3 to sync all the version numbers.
  * Publish Meadow.CLI nuget
  * Publish Windows extensions to the Marketplace
  * Publish VSCode extension to the Marketplace
  * Create a Release on the VS_Mac repo. Currently we just need to copy the *mpacks to the respective release (will attempt to automate this too in a future release)
  
**Pre-requisites:**
We need to ensure that all extension PRs to `main` have been merged into their respective `main` branches, before the `Meadow.CLI` PR to `main` gets merged. This ensures that when the `Meadow.CLI` PR  to `main` gets merged all the correct extension `main` branches are correctly built and then therefore published.

**TODO**
- [ ] Once this PR gets merged, I'll remove publishing from VSCode and Windows extensions, so it only ever happens here.