### PR TITLE
Change StdOut parsing charset to UTF-8 from ASCII

### DIFF
--- a/Meadow.CLI.Core/Internals/MeadowCommunication/ReceiveClasses/ReceiveMessageFactoryManager.cs
+++ b/Meadow.CLI.Core/Internals/MeadowCommunication/ReceiveClasses/ReceiveMessageFactoryManager.cs
@@ -24,7 +24,7 @@ namespace Meadow.CLI.Core.Internals.MeadowCommunication.ReceiveClasses
                 {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_LIST_HEADER, new ReceiveSimpleTextFactory() },
                 {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_LIST_MEMBER, new ReceiveSimpleTextFactory() },
                 {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_CRC_MEMBER, new ReceiveSimpleTextFactory() },
-                {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_MONO_STDOUT, new ReceiveSimpleTextFactory() },
+                {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_MONO_STDOUT, new ReceiveSimpleTextUTF8Factory() },
                 {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_DEVICE_INFO, new ReceiveSimpleTextFactory() },
                 {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_TRACE_MSG, new ReceiveSimpleTextFactory() },
                 {HcomHostRequestType.HCOM_HOST_REQUEST_TEXT_RECONNECT, new ReceiveSimpleTextFactory() },

--- a/Meadow.CLI.Core/Internals/MeadowCommunication/ReceiveClasses/ReceiveSimpleText.cs
+++ b/Meadow.CLI.Core/Internals/MeadowCommunication/ReceiveClasses/ReceiveSimpleText.cs
@@ -5,8 +5,15 @@ namespace Meadow.CLI.Core.Internals.MeadowCommunication.ReceiveClasses
 {
     internal class ReceiveSimpleText : ReceiveHeader
     {
+        private Encoding _encoding = Encoding.ASCII;
+
         public ReceiveSimpleText(byte[] receivedMessage) : base(receivedMessage)
         {
+        }
+
+        public ReceiveSimpleText(byte[] receivedMessage, Encoding encoding) : base(receivedMessage)
+        {
+            _encoding = encoding;
         }
 
         public override bool Execute(byte[] receivedMessage)
@@ -28,7 +35,7 @@ namespace Meadow.CLI.Core.Internals.MeadowCommunication.ReceiveClasses
         }
         public override string ToString()
         {
-            return MessageDataLength > 0 ? Encoding.ASCII.GetString(MessageData!) : string.Empty;
+            return MessageDataLength > 0 ? _encoding.GetString(MessageData!) : string.Empty;
         }
     }
 }

--- a/Meadow.CLI.Core/Internals/MeadowCommunication/ReceiveClasses/ReceiveSimpleTextUTF8Factory.cs
+++ b/Meadow.CLI.Core/Internals/MeadowCommunication/ReceiveClasses/ReceiveSimpleTextUTF8Factory.cs
@@ -1,0 +1,9 @@
+using System.Text;
+
+namespace Meadow.CLI.Core.Internals.MeadowCommunication.ReceiveClasses
+{
+    public class ReceiveSimpleTextUTF8Factory : ReceiveMessageFactory
+    {
+        public override IReceivedMessage Create(byte[] receivedMessage) => new ReceiveSimpleText(receivedMessage, Encoding.UTF8);
+    }
+}


### PR DESCRIPTION
Proposed fix for #278. This is similar to #279 but only changes parsing for StdOut to use UTF-8.