### PR TITLE
Create package with / path separator always

### DIFF
--- a/Meadow.CLI.Core/Managers/PackageManager.cs
+++ b/Meadow.CLI.Core/Managers/PackageManager.cs
@@ -72,7 +72,7 @@ namespace Meadow.CLI.Core
                     {
                         foreach (var fPath in appFiles)
                         {
-                            archive.CreateEntryFromFile(fPath, Path.Combine("app", Path.GetFileName(fPath)));
+                            CreateEntry(archive, fPath, Path.Combine("app", Path.GetFileName(fPath)));
                         }
                     }
                     
@@ -80,7 +80,7 @@ namespace Meadow.CLI.Core
                     {
                         foreach (var fPath in osFiles)
                         {
-                            archive.CreateEntryFromFile(fPath, Path.Combine("os", Path.GetFileName(fPath)));
+                            CreateEntry(archive, fPath, Path.Combine("os", Path.GetFileName(fPath)));
                         }
                     }
                 }
@@ -91,6 +91,18 @@ namespace Meadow.CLI.Core
                 _logger.LogError("Application Path or OS Version was not specified.");
                 return string.Empty;
             }
+        }
+
+        void CreateEntry(ZipArchive archive, string fromFile, string entryPath)
+        {
+            // Windows '\' Path separator character will be written to the zip which meadow os does not properly unpack
+            //  See: https://github.com/dotnet/runtime/issues/41914
+            if (OperatingSystem.IsWindows())
+            {
+                entryPath = entryPath.Replace('\\', '/');
+            }
+
+            archive.CreateEntryFromFile(fromFile, entryPath);
         }
     }
 }

--- a/Meadow.CLI.Core/Managers/PackageManager.cs
+++ b/Meadow.CLI.Core/Managers/PackageManager.cs
@@ -1,14 +1,9 @@
-﻿using Meadow.CLI.Core.Identity;
-using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Meadow.CLI.Core
 {
@@ -97,7 +92,7 @@ namespace Meadow.CLI.Core
         {
             // Windows '\' Path separator character will be written to the zip which meadow os does not properly unpack
             //  See: https://github.com/dotnet/runtime/issues/41914
-            if (OperatingSystem.IsWindows())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 entryPath = entryPath.Replace('\\', '/');
             }


### PR DESCRIPTION
Windows `CreateEntryFromFile` will use the `\` windows path separator character when writing the zip file entry.  This might be fine and technically within spec, but when the update is extracted on the device it does not create the correct folder structure (so it seems `app\file.ext` is considered a file instead of a file within the `app` folder). See: https://github.com/dotnet/runtime/issues/41914

This just ensures on windows, the `/` separator replaces `\` instances when creating the package to avoid the issue.