### PR TITLE
fixes to exclude Meadow.OS.bin from package

### DIFF
--- a/Meadow.CLI.Core/Managers/PackageManager.cs
+++ b/Meadow.CLI.Core/Managers/PackageManager.cs
@@ -14,9 +14,14 @@ namespace Meadow.CLI.Core
 {
     public class PackageManager
     {
+        private List<string> _firmwareFilesExclude;
         public PackageManager(ILoggerFactory loggerFactory)
         {
             _logger = loggerFactory.CreateLogger<PackageManager>();
+            _firmwareFilesExclude = new List<string>()
+            {
+                "Meadow.OS.bin".ToLower()
+            };
         }
 
         private readonly ILogger _logger;
@@ -53,7 +58,9 @@ namespace Meadow.CLI.Core
                 {
                     throw new ArgumentException($"osVersion {osVersion} not found. Please download.");
                 }
-                osFiles = Directory.GetFiles(osFilePath);
+
+                osFiles = Directory.GetFiles(osFilePath)
+                    .Where(x => !_firmwareFilesExclude.Contains(new FileInfo(x).Name.ToLower())).ToArray();
             }
             
             if(appFiles != null || osFiles !=null)

--- a/Meadow.CLI/Properties/launchSettings.json
+++ b/Meadow.CLI/Properties/launchSettings.json
@@ -78,7 +78,7 @@
     },
     "Package Create": {
       "commandName": "Project",
-      "commandLineArgs": "package create -a C:\\Users\\brikim\\gh\\SimpleMqttServer\\src\\DeviceClient\\bin\\Debug\\Netstandard2.1 -v 0.6.4.0"
+      "commandLineArgs": "package create -v 1.0.0.0"
     },
     "Package List": {
       "commandName": "Project",


### PR DESCRIPTION
Output of command, notice no Meadow.OS.bin file:

<img width="209" alt="image" src="https://github.com/WildernessLabs/Meadow.CLI/assets/1048330/584b8bf9-bfe6-43c0-86fe-67e2268bffd1">
