### PR TITLE
add metadata param for package publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,5 @@ SourceVersions
 
 # NETMF
 OnBoardFlash.dat
+
+.vscode

--- a/Meadow.CLI.Core/CloudServices/CollectionService.cs
+++ b/Meadow.CLI.Core/CloudServices/CollectionService.cs
@@ -25,8 +25,13 @@ public class CollectionService : CloudServiceBase
         _identityManager = identityManager;
     }
     
-    public async Task<List<Collection>> GetOrgCollections(string orgId, CancellationToken cancellationToken)
+    public async Task<List<Collection>> GetOrgCollections(string orgId, string host, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrEmpty(host))
+        {
+            host = _config["meadowCloudHost"];
+        }
+
         var authToken = await _identityManager.GetAccessToken(cancellationToken).ConfigureAwait(false);
         if (string.IsNullOrEmpty(authToken))
         {
@@ -36,7 +41,7 @@ public class CollectionService : CloudServiceBase
         HttpClient httpClient = new HttpClient();
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
 
-        var result = await httpClient.GetStringAsync($"{_config["meadowCloudHost"]}/api/orgs/{orgId}/collections");
+        var result = await httpClient.GetStringAsync($"{host}/api/orgs/{orgId}/collections");
         return JsonSerializer.Deserialize<List<Collection>>(result);
     }
 }

--- a/Meadow.CLI.Core/CloudServices/CollectionService.cs
+++ b/Meadow.CLI.Core/CloudServices/CollectionService.cs
@@ -29,7 +29,7 @@ public class CollectionService : CloudServiceBase
     {
         if (string.IsNullOrEmpty(host))
         {
-            host = _config["meadowCloudHost"];
+            host = _config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME];
         }
 
         var authToken = await _identityManager.GetAccessToken(cancellationToken).ConfigureAwait(false);

--- a/Meadow.CLI.Core/CloudServices/DeviceService.cs
+++ b/Meadow.CLI.Core/CloudServices/DeviceService.cs
@@ -19,8 +19,13 @@ namespace Meadow.CLI.Core.CloudServices
             _config = config;
         }
 
-        public async Task<(bool isSuccess, string message)> AddDevice(string orgId, string id, string publicKey, string collectionId)
+        public async Task<(bool isSuccess, string message)> AddDevice(string orgId, string id, string publicKey, string collectionId, string host)
         {
+            if (string.IsNullOrEmpty(host))
+            {
+                host = _config["meadowCloudHost"];
+            }
+            
             var httpClient = await AuthenticatedHttpClient();
 
             dynamic payload = new
@@ -34,7 +39,7 @@ namespace Meadow.CLI.Core.CloudServices
             var json = JsonSerializer.Serialize<dynamic>(payload);
 
             var content = new StringContent(json, Encoding.UTF8, "application/json");
-            var response  = await httpClient.PostAsync($"{_config["meadowCloudHost"]}/api/devices", content);
+            var response  = await httpClient.PostAsync($"{host}/api/devices", content);
 
             if (response.IsSuccessStatusCode)
             {

--- a/Meadow.CLI.Core/CloudServices/DeviceService.cs
+++ b/Meadow.CLI.Core/CloudServices/DeviceService.cs
@@ -23,7 +23,7 @@ namespace Meadow.CLI.Core.CloudServices
         {
             if (string.IsNullOrEmpty(host))
             {
-                host = _config["meadowCloudHost"];
+                host = _config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME];
             }
             
             var httpClient = await AuthenticatedHttpClient();

--- a/Meadow.CLI.Core/CloudServices/PackageService.cs
+++ b/Meadow.CLI.Core/CloudServices/PackageService.cs
@@ -30,7 +30,7 @@ namespace Meadow.CLI.Core.CloudServices
         {
             if (string.IsNullOrEmpty(host))
             {
-                host = _config["meadowCloudHost"];
+                host = _config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME];
             }
             
             if (!File.Exists(mpakPath))
@@ -77,7 +77,7 @@ namespace Meadow.CLI.Core.CloudServices
         {
             if (string.IsNullOrEmpty(host))
             {
-                host = _config["meadowCloudHost"];
+                host = _config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME];
             }
             
             var authToken = await _identityManager.GetAccessToken(cancellationToken).ConfigureAwait(false);
@@ -104,7 +104,7 @@ namespace Meadow.CLI.Core.CloudServices
         {
             if (string.IsNullOrEmpty(host))
             {
-                host = _config["meadowCloudHost"];
+                host = _config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME];
             }
             
             var authToken = await _identityManager.GetAccessToken(cancellationToken).ConfigureAwait(false);

--- a/Meadow.CLI.Core/CloudServices/PackageService.cs
+++ b/Meadow.CLI.Core/CloudServices/PackageService.cs
@@ -89,9 +89,9 @@ namespace Meadow.CLI.Core.CloudServices
             HttpClient httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authToken);
 
-            var payload = new { metadata = metadata };
+            var payload = new { metadata, collectionId };
             var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-            var response = await httpClient.PostAsync($"{host}/api/packages/{packageId}/publish/{collectionId}", content);
+            var response = await httpClient.PostAsync($"{host}/api/packages/{packageId}/publish", content);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/Meadow.CLI.Core/CloudServices/UserService.cs
+++ b/Meadow.CLI.Core/CloudServices/UserService.cs
@@ -27,7 +27,7 @@ namespace Meadow.CLI.Core.CloudServices
         {
             if (string.IsNullOrEmpty(host))
             {
-                host = _config["meadowCloudHost"];
+                host = _config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME];
             }
             
             var httpClient = await AuthenticatedHttpClient();

--- a/Meadow.CLI.Core/CloudServices/UserService.cs
+++ b/Meadow.CLI.Core/CloudServices/UserService.cs
@@ -23,11 +23,16 @@ namespace Meadow.CLI.Core.CloudServices
             _config = config;
         }
 
-        public async Task<List<UserOrg>> GetUserOrgs(CancellationToken cancellationToken)
+        public async Task<List<UserOrg>> GetUserOrgs(string host, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrEmpty(host))
+            {
+                host = _config["meadowCloudHost"];
+            }
+            
             var httpClient = await AuthenticatedHttpClient();
 
-            var response = await httpClient.GetAsync($"{_config["meadowCloudHost"]}/api/users/me/orgs");
+            var response = await httpClient.GetAsync($"{host}/api/users/me/orgs");
 
             if (response.IsSuccessStatusCode)
             {

--- a/Meadow.CLI.Core/Constants.cs
+++ b/Meadow.CLI.Core/Constants.cs
@@ -11,5 +11,6 @@ namespace Meadow.CLI.Core
         public const ushort HCOM_PROTOCOL_PREVIOUS_VERSION_NUMBER = 0x0006;
         public const ushort HCOM_PROTOCOL_CURRENT_VERSION_NUMBER = 0x0007;         // Used for transmission
         public const string WILDERNESS_LABS_USB_VID = "2E6A";
+        public const string MEADOW_CLOUD_HOST_CONFIG_NAME = "meadowCloudHost";
     }
 }

--- a/Meadow.CLI/Commands/Cloud/Collection/ListCollectionCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Collection/ListCollectionCommand.cs
@@ -31,6 +31,8 @@ public class ListCollectionCommand
 
         [CommandOption("orgId", 'o', Description = "Organization Id", IsRequired = false)]
         public string OrgId { get; set; }
+        [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
+        public string Host { get; set; }
 
         public async ValueTask ExecuteAsync(IConsole console)
         {
@@ -40,7 +42,7 @@ public class ListCollectionCommand
 
             try
             {
-                var userOrgs = await _userService.GetUserOrgs(cancellationToken).ConfigureAwait(false);
+                var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
                     _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
@@ -67,8 +69,8 @@ public class ListCollectionCommand
                 _logger.LogInformation($"You must be signed in to execute this command.");
                 return;
             }
-
-            var collections = await _collectionService.GetOrgCollections(OrgId, cancellationToken);
+            
+            var collections = await _collectionService.GetOrgCollections(OrgId, Host, cancellationToken);
 
             if (collections == null || collections.Count() == 0)
             {

--- a/Meadow.CLI/Commands/Cloud/Collection/ListCollectionCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Collection/ListCollectionCommand.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
+using Meadow.CLI.Core;
 using Meadow.CLI.Core.CloudServices;
 using Meadow.CLI.Core.Exceptions;
 using Microsoft.Extensions.Configuration;
@@ -45,7 +46,7 @@ public class ListCollectionCommand
                 var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
-                    _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
+                    _logger.LogInformation($"Please visit {_config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME]} to register your account.");
                     return;
                 }
                 else if (userOrgs.Count() > 1 && string.IsNullOrEmpty(OrgId))

--- a/Meadow.CLI/Commands/Cloud/Package/ListPackagesCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/ListPackagesCommand.cs
@@ -54,7 +54,7 @@ namespace Meadow.CLI.Commands.Cloud
                 var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
-                    _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
+                    _logger.LogInformation($"Please visit {_config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME]} to register your account.");
                     return;
                 }
                 else if (userOrgs.Count() > 1 && string.IsNullOrEmpty(OrgId))

--- a/Meadow.CLI/Commands/Cloud/Package/ListPackagesCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/ListPackagesCommand.cs
@@ -40,7 +40,9 @@ namespace Meadow.CLI.Commands.Cloud
 
         [CommandOption("orgId", 'o', Description = "Organization Id", IsRequired = false)]
         public string OrgId { get; set; }
-
+        [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
+        public string Host { get; set; }
+        
         public async ValueTask ExecuteAsync(IConsole console)
         {
             var cancellationToken = console.RegisterCancellationHandler();
@@ -49,7 +51,7 @@ namespace Meadow.CLI.Commands.Cloud
 
             try
             {
-                var userOrgs = await _userService.GetUserOrgs(cancellationToken).ConfigureAwait(false);
+                var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
                     _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
@@ -77,8 +79,8 @@ namespace Meadow.CLI.Commands.Cloud
                 _logger.LogInformation($"You must be signed in to execute this command.");
                 return;
             }
-
-            var packages = await _packageService.GetOrgPackages(OrgId, cancellationToken);
+            
+            var packages = await _packageService.GetOrgPackages(OrgId, Host, cancellationToken);
 
             if(packages == null || packages.Count() == 0)
             {

--- a/Meadow.CLI/Commands/Cloud/Package/PublishPackageCommend.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/PublishPackageCommend.cs
@@ -36,6 +36,10 @@ namespace Meadow.CLI.Commands.Cloud
         public string PackageId { get; init; }
         [CommandOption("collectionId", 'c', Description = "The target collection for publishing", IsRequired = true)]
         public string CollectionId { get; set; }
+        [CommandOption("metadata", 'm', Description = "Pass through metadata", IsRequired = false)]
+        public string Metadata { get; set; }
+        [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
+        public string Host { get; set; }
 
         public async ValueTask ExecuteAsync(IConsole console)
         {
@@ -45,7 +49,7 @@ namespace Meadow.CLI.Commands.Cloud
 
             try
             {
-                await _packageService.PublishPackage(PackageId, CollectionId, cancellationToken);
+                await _packageService.PublishPackage(PackageId, CollectionId, Metadata, Host, cancellationToken);
                 _logger.LogInformation("Publish successful.");
             }
             catch(MeadowCloudException mex)

--- a/Meadow.CLI/Commands/Cloud/Package/UploadPackageCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/UploadPackageCommand.cs
@@ -46,7 +46,8 @@ namespace Meadow.CLI.Commands.Cloud
 
         [CommandOption("description", 'd', Description = "Description of the package", IsRequired = false)]
         public string Description { get; set; }
-
+        [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
+        public string Host { get; set; }
         public async ValueTask ExecuteAsync(IConsole console)
         {
             var cancellationToken = console.RegisterCancellationHandler();
@@ -55,7 +56,7 @@ namespace Meadow.CLI.Commands.Cloud
 
             try
             {
-                var userOrgs = await _userService.GetUserOrgs(cancellationToken).ConfigureAwait(false);
+                var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
                     _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
@@ -86,7 +87,7 @@ namespace Meadow.CLI.Commands.Cloud
 
             try
             {
-                var package = await _packageService.UploadPackage(MpakPath, OrgId, Description, cancellationToken);
+                var package = await _packageService.UploadPackage(MpakPath, OrgId, Description, Host, cancellationToken);
                 _logger.LogInformation($"Upload complete. Package Id: {package.Id}");
             }
             catch (MeadowCloudException mex)

--- a/Meadow.CLI/Commands/Cloud/Package/UploadPackageCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/UploadPackageCommand.cs
@@ -59,7 +59,7 @@ namespace Meadow.CLI.Commands.Cloud
                 var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
-                    _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
+                    _logger.LogInformation($"Please visit {_config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME]} to register your account.");
                     return;
                 }
                 else if (userOrgs.Count() > 1 && string.IsNullOrEmpty(OrgId))

--- a/Meadow.CLI/Commands/DeviceManagement/ProvisionDeviceCommand.cs
+++ b/Meadow.CLI/Commands/DeviceManagement/ProvisionDeviceCommand.cs
@@ -52,7 +52,7 @@ namespace Meadow.CommandLine.Commands.Cloud
                 var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
-                    _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
+                    _logger.LogInformation($"Please visit {_config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME]} to register your account.");
                     return;
                 }
                 else if (userOrgs.Count() > 1 && string.IsNullOrEmpty(OrgId))

--- a/Meadow.CLI/Commands/DeviceManagement/ProvisionDeviceCommand.cs
+++ b/Meadow.CLI/Commands/DeviceManagement/ProvisionDeviceCommand.cs
@@ -39,7 +39,9 @@ namespace Meadow.CommandLine.Commands.Cloud
         public string OrgId { get; set; }
         [CommandOption("collectionId", 'c', Description = "The target collection for device registration", IsRequired = false)]
         public string CollectionId { get; set; }
-
+        [CommandOption("host", 'h', Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
+        public string Host { get; set; }
+        
         public override async ValueTask ExecuteAsync(IConsole console)
         {
             await base.ExecuteAsync(console);
@@ -47,7 +49,7 @@ namespace Meadow.CommandLine.Commands.Cloud
 
             try
             {
-                var userOrgs = await _userService.GetUserOrgs(cancellationToken).ConfigureAwait(false);
+                var userOrgs = await _userService.GetUserOrgs(Host, cancellationToken).ConfigureAwait(false);
                 if (!userOrgs.Any())
                 {
                     _logger.LogInformation($"Please visit {_config["meadowCloudHost"]} to register your account.");
@@ -76,12 +78,13 @@ namespace Meadow.CommandLine.Commands.Cloud
                 return;
             }
 
+            
             using var device = await MeadowDeviceManager.GetMeadowForSerialPort(this.SerialPortName, true, _logger);
             var publicKey = await device.CloudRegisterDevice(cancellationToken);
             var delim = "-----END PUBLIC KEY-----\n";
             publicKey = publicKey.Substring(0, publicKey.IndexOf(delim) + delim.Length);
-
-            var result = await _deviceService.AddDevice(OrgId, device.DeviceInfo.ProcessorId, publicKey, CollectionId);
+            
+            var result = await _deviceService.AddDevice(OrgId, device.DeviceInfo.ProcessorId, publicKey, CollectionId, Host);
 
             if (result.isSuccess)
             {

--- a/Meadow.CLI/Properties/launchSettings.json
+++ b/Meadow.CLI/Properties/launchSettings.json
@@ -82,11 +82,11 @@
     },
     "Package List": {
       "commandName": "Project",
-      "commandLineArgs": "package list -o 5b1d2b0dab744a04b79b245d881e18b8 --host https://staging.meadowcloud.dev"
+      "commandLineArgs": "package list -o 5b1d2b0dab744a04b79b245d881e18b8"
     },
     "Package Publish": {
       "commandName": "Project",
-      "commandLineArgs": "package publish -p 7aedf4b3e304482e97f2a43041ebc30b -c 4965ba4d6b504c879928494e9bbe415d -m \"this is my metadata\" --host https://staging.meadowcloud.dev"
+      "commandLineArgs": "package publish -p 7aedf4b3e304482e97f2a43041ebc30b -c 4965ba4d6b504c879928494e9bbe415d -m \"this is my metadata\""
     },
     "Package Upload": {
       "commandName": "Project",
@@ -94,7 +94,7 @@
     },
     "Collection List": {
       "commandName": "Project",
-      "commandLineArgs": "collection list -h https://staging.meadowcloud.dev"
+      "commandLineArgs": "collection list"
     },
     "RegisterDevice": {
       "commandName": "Project",

--- a/Meadow.CLI/Properties/launchSettings.json
+++ b/Meadow.CLI/Properties/launchSettings.json
@@ -14,7 +14,7 @@
     },
     "DeviceProvision": {
       "commandName": "Project",
-      "commandLineArgs": "device provision"
+      "commandLineArgs": "device provision -o 5b1d2b0dab744a04b79b245d881e18b8"
     },
     "DeviceInfo": {
       "commandName": "Project",
@@ -82,11 +82,11 @@
     },
     "Package List": {
       "commandName": "Project",
-      "commandLineArgs": "package list"
+      "commandLineArgs": "package list -o 5b1d2b0dab744a04b79b245d881e18b8 --host https://staging.meadowcloud.dev"
     },
     "Package Publish": {
       "commandName": "Project",
-      "commandLineArgs": "package publish -p 485f06def49740ea9615208ba6107d2a -c 4965ba4d6b504c879928494e9bbe415d"
+      "commandLineArgs": "package publish -p 7aedf4b3e304482e97f2a43041ebc30b -c 4965ba4d6b504c879928494e9bbe415d -m \"this is my metadata\" --host https://staging.meadowcloud.dev"
     },
     "Package Upload": {
       "commandName": "Project",
@@ -94,7 +94,7 @@
     },
     "Collection List": {
       "commandName": "Project",
-      "commandLineArgs": "collection list"
+      "commandLineArgs": "collection list -h https://staging.meadowcloud.dev"
     },
     "RegisterDevice": {
       "commandName": "Project",


### PR DESCRIPTION
* for package publish, add ability to specify `--metadata`. Also, updated publish endpoint uri.
* add the ability to specify a `Host` value for cloud related commands. This is especially helpful when trying to use the CLI with staging or localhost.