### PR TITLE
Create new SerialPort object  when System.OperationException occurs

### DIFF
--- a/Meadow.CLI.Core/Devices/MeadowSerialDevice.cs
+++ b/Meadow.CLI.Core/Devices/MeadowSerialDevice.cs
@@ -111,7 +111,7 @@ namespace Meadow.CLI.Core.Devices
             throw new Exception($"Device not ready after {initTimeout}s");
         }
 
-        private static SerialPort OpenSerialPort(string portName)
+        internal static SerialPort OpenSerialPort(string portName)
         {
             if (string.IsNullOrEmpty(portName))
             {

--- a/Meadow.CLI.Core/Internals/MeadowCommunication/MeadowSerialDataProcessor.cs
+++ b/Meadow.CLI.Core/Internals/MeadowCommunication/MeadowSerialDataProcessor.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
+using Meadow.CLI.Core.Devices;
 
 namespace Meadow.CLI.Core.Internals.MeadowCommunication
 {
@@ -41,7 +42,7 @@ namespace Meadow.CLI.Core.Internals.MeadowCommunication
     {
         private readonly ILogger _logger;
         //collapse to one and use enum
-        private readonly SerialPort _serialPort;
+        private /*readonly*/ SerialPort _serialPort;
         readonly Socket _socket;
         private readonly Task _dataProcessorTask;
 
@@ -208,6 +209,22 @@ namespace Meadow.CLI.Core.Internals.MeadowCommunication
                                     message = null;
                                 }
                             }
+                        }
+                    }
+                    catch (System.OperationCanceledException ex)
+                    {
+                        string portName = _serialPort.PortName;
+                        if (ex.Message == "The operation was canceled.")
+                        {
+                            _logger?.LogCritical( "-----------------------------------------------------");
+                            _logger?.LogCritical( "An error occurred while listening to the serial port.");
+                            _logger?.LogCritical($"Open new MeadowSerialDevice.OpenSerialPort(\"{_serialPort.PortName}\")");
+                            _logger?.LogCritical( "-----------------------------------------------------");
+                            _serialPort = MeadowSerialDevice.OpenSerialPort(_serialPort.PortName);
+                        }
+                        else
+                        {
+                            _logger.LogCritical(ex,$"An error occurred while listening to the serial port. ex.Message={ex.Message}");
                         }
                     }
                     catch (TimeoutException)


### PR DESCRIPTION
Recreate SerialPort object when Meadow is reset and the SerialPort connection is lost.

This change feels like a hack, however simple testing shows it works. With this change, I can do `meadow listen` and then reset the Meadow by pressing the physical Reset button or I can Publish a new app from the cloud and listen reconnects when the Meadow restarts after outputting a message.

```Meadow StdOut: Updater State -> Idle
Meadow StdOut: Updater State -> UpdateInProgress
Meadow StdOut: Applying update from '/meadow0/update-store/42c6dcf2bdf243b389fca94303792b2d/42c6dcf2bdf243b389fca94303792b2d.zip'
Meadow StdOut: Extracting update to '/meadow0/update'...
Meadow StdOut: Extracting took 2.595 seconds.
Meadow StdOut: Contents of Update
Meadow StdOut: ------------------
Meadow StdOut: + update
Meadow StdOut: + update
Meadow StdOut: + app
Meadow StdOut: - App.dll
Meadow StdOut: + alt-min
Meadow StdOut: Stopping application to allow update
Meadow StdOut: Requesting a device reset to apply the Update
Meadow StdOut: Resetting device...
-----------------------------------------------------
An error occurred while listening to the serial port.
Open new MeadowSerialDevice.OpenSerialPort("COM6")
-----------------------------------------------------
Meadow StdInfo: Meadow successfully started MONO
Meadow StdOut: Log level: Trace
Meadow StdOut: LoadSettings took 5110
Meadow StdOut: Looking for app assembly...
Meadow StdOut: Found '/meadow0/App.dll'
Meadow StdOut: Looking for IApp...
Meadow StdOut: App is type MeadowApp
Meadow StdOut: Finding 'MeadowApp' took 0ms
Meadow StdOut: Creating 'F7FeatherV2' instance took 1635ms
Meadow StdOut: Device Initialize starting...
Meadow StdOut: Device is configured to use WiFi for the network interface```
```
Long term might be better to pass in a `SerialPortFactory` rather than a `SerialPort` given SerialPort.Close() or SerialPort.Dispose() amount to the same thing forcing one to do a new SerialPort(...) 

Testing was only done on Windows, need to test on other supported platforms.

### Testing Steps - Local Hardware Reset. ###
1. deploy application to meadow.
2. Run `meadow listen` and confirm trace output displayed from running application
3. Press Reset button on Meadow to restart the hardware.
4. Meadow CLI should display a banner warning connection to Meadow lost
5. When Meadow reboots, the trace output should be displayed after the banner without needing to close CLI and re-run `meadow listen`

### OTA publish ###
1. Deploy OTA enabled application to meadow
2. Run `meadow listen` and confirm trace output displayed from running application
3. Publish OTA update
4. Meadow should reboot once OTA update has been applied.
5. Meadow listen should automatically reconnect and continue to display the trace output without re-running `meadow listen`