### PR TITLE
big `meadow package create` improvements

### DIFF
--- a/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
+++ b/Meadow.CLI.Core/DeviceManagement/AssemblyManager.cs
@@ -103,14 +103,21 @@ namespace Meadow.CLI.Core.DeviceManagement
                 using (StreamReader stdOutReader = process.StandardOutput)
                 {
                     stdOutReaderResult = await stdOutReader.ReadToEndAsync();
-                    Console.WriteLine("StandardOutput Contains: " + stdOutReaderResult);
+                    if (verbose)
+                    {
+                        Console.WriteLine("StandardOutput Contains: " + stdOutReaderResult);
+                    }
+                    
                 }
 
                 string stdErrorReaderResult;
                 using (StreamReader stdErrorReader = process.StandardError)
                 {
                     stdErrorReaderResult = await stdErrorReader.ReadToEndAsync();
-                    Console.WriteLine("StandardError Contains: " + stdErrorReaderResult);
+                    if (!string.IsNullOrEmpty(stdErrorReaderResult))
+                    {
+                        Console.WriteLine("StandardError Contains: " + stdErrorReaderResult);
+                    }
                 }
 
                 process.WaitForExit(60000);

--- a/Meadow.CLI.Core/Managers/PackageManager.cs
+++ b/Meadow.CLI.Core/Managers/PackageManager.cs
@@ -1,15 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Dynamic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Xml;
+using GlobExpressions;
+using Meadow.CLI.Core.DeviceManagement;
 
 namespace Meadow.CLI.Core
 {
     public class PackageManager
     {
         private List<string> _firmwareFilesExclude;
+
         public PackageManager(ILoggerFactory loggerFactory)
         {
             _logger = loggerFactory.CreateLogger<PackageManager>();
@@ -21,71 +29,128 @@ namespace Meadow.CLI.Core
 
         private readonly ILogger _logger;
 
-        public string CreatePackage(string applicationPath, string osVersion)
+        public async Task<string> CreatePackage(string projectPath, string osVersion, string mpakName, string globPath)
         {
-            string[]? osFiles = null;
-            string[]? appFiles = null;
+            var projectPathInfo = new FileInfo(projectPath);
 
-            if(!string.IsNullOrEmpty(applicationPath))
+            BuildProject(projectPath);
+            var targetFramework = GetProjectTargetFramework(projectPath);
+
+            var targetFrameworkDir = Path.Combine(projectPathInfo.DirectoryName, "bin", "Debug", targetFramework);
+            string appDllPath = Path.Combine(targetFrameworkDir, "App.dll");
+
+            await TrimDependencies(appDllPath, osVersion);
+
+            var postlinkBinDir = Path.Combine(targetFrameworkDir, "postlink_bin");
+
+            return CreateMpak(postlinkBinDir, mpakName, osVersion, globPath);
+        }
+
+        void BuildProject(string projectPath)
+        {
+            // run dotnet build on the project file
+            var proc = new Process();
+            proc.StartInfo.FileName = "dotnet";
+            proc.StartInfo.Arguments = $"build {projectPath}";
+
+            proc.StartInfo.CreateNoWindow = true;
+            proc.StartInfo.ErrorDialog = false;
+            proc.StartInfo.RedirectStandardError = true;
+            proc.StartInfo.RedirectStandardOutput = true;
+            proc.StartInfo.UseShellExecute = false;
+
+            proc.ErrorDataReceived += (sendingProcess, errorLine) => Console.WriteLine(errorLine.Data);
+            proc.OutputDataReceived += (sendingProcess, dataLine) => Console.WriteLine(dataLine.Data);
+
+            proc.Start();
+            proc.BeginErrorReadLine();
+            proc.BeginOutputReadLine();
+
+            proc.WaitForExit();
+            var exitCode = proc.ExitCode;
+            proc.Close();
+
+            if (exitCode != 0)
             {
-                if (!File.Exists(applicationPath) && !Directory.Exists(applicationPath))
+                _logger.LogError("Package creation aborted. Build failed.");
+                Environment.Exit(0);
+            }
+        }
+
+        string GetProjectTargetFramework(string projectPath)
+        {
+            // open the project file to get the TargetFramework value
+            XmlDocument doc = new XmlDocument();
+            doc.Load(projectPath);
+            return doc?.DocumentElement?.SelectSingleNode("/Project/PropertyGroup/TargetFramework")?.InnerText;
+        }
+
+        async Task TrimDependencies(string appDllPath, string osVersion)
+        {
+            FileInfo projectAppDll = new FileInfo(appDllPath);
+
+            var dependencies = AssemblyManager
+                .GetDependencies(projectAppDll.Name, projectAppDll.DirectoryName, osVersion)
+                .Where(x => x.Contains("App.") == false)
+                .ToList();
+
+            await AssemblyManager.TrimDependencies(projectAppDll.Name, projectAppDll.DirectoryName, dependencies, null,
+                null, false, verbose: false);
+        }
+
+        string CreateMpak(string postlinkBinDir, string mpakName, string osVersion, string globPath)
+        {
+            if (string.IsNullOrEmpty(mpakName))
+            {
+                mpakName = $"{DateTime.UtcNow.ToString("yyyyMMdd")}{DateTime.UtcNow.Millisecond.ToString()}.mpak";
+            }
+
+            if (!mpakName.EndsWith(".mpak"))
+            {
+                mpakName += ".mpak";
+            }
+
+            var mpakPath = Path.Combine(Environment.CurrentDirectory, mpakName);
+
+            if (File.Exists(mpakPath))
+            {
+                Console.WriteLine($"{mpakPath} already exists. Do you with to overwrite (Y/n)");
+
+                while (true)
                 {
-                    throw new ArgumentException($"Invalid applicationPath: {applicationPath}");
-                }
-                else
-                {
-                    var fi = new FileInfo(applicationPath);
-                    if ((fi.Attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                    Console.Write("> ");
+                    var input = Console.ReadKey();
+                    switch (input.Key)
                     {
-                        appFiles = Directory.GetFiles(applicationPath);
+                        case ConsoleKey.Y:
+                            File.Delete(mpakPath);
+                            break;
+                        case ConsoleKey.N:
+                            Environment.Exit(0);
+                            break;
+                        default:
+                            continue;
                     }
-                    else
-                    {
-                        appFiles = new[] { fi.FullName };
-                    }
+
+                    break;
                 }
             }
 
-            if(!string.IsNullOrEmpty(osVersion))
-            {
-                var osFilePath = Path.Combine(DownloadManager.FirmwareDownloadsFilePathRoot, osVersion);
-                if (!Directory.Exists(osFilePath))
-                {
-                    throw new ArgumentException($"osVersion {osVersion} not found. Please download.");
-                }
+            var appFiles = Glob.Files(postlinkBinDir, globPath, GlobOptions.CaseInsensitive).ToArray();
+            using var archive = ZipFile.Open(mpakPath, ZipArchiveMode.Create);
 
-                osFiles = Directory.GetFiles(osFilePath)
-                    .Where(x => !_firmwareFilesExclude.Contains(new FileInfo(x).Name.ToLower())).ToArray();
-            }
-            
-            if(appFiles != null || osFiles !=null)
+            foreach (var fPath in appFiles)
             {
-                var zipFile = Path.Combine(Environment.CurrentDirectory, $"{DateTime.UtcNow.ToString("yyyyMMdd")}{DateTime.UtcNow.Millisecond.ToString()}.mpak");
-                using (var archive = ZipFile.Open(zipFile, ZipArchiveMode.Create))
-                {
-                    if(appFiles != null)
-                    {
-                        foreach (var fPath in appFiles)
-                        {
-                            CreateEntry(archive, fPath, Path.Combine("app", Path.GetFileName(fPath)));
-                        }
-                    }
-                    
-                    if(osFiles != null)
-                    {
-                        foreach (var fPath in osFiles)
-                        {
-                            CreateEntry(archive, fPath, Path.Combine("os", Path.GetFileName(fPath)));
-                        }
-                    }
-                }
-                return zipFile;
+                CreateEntry(archive, Path.Combine(postlinkBinDir, fPath), Path.Combine("app", Path.GetFileName(fPath)));
             }
-            else
-            {
-                _logger.LogError("Application Path or OS Version was not specified.");
-                return string.Empty;
-            }
+
+            // write a metadata file info.json in the mpak
+            var info = new { v = 1, osVersion };
+            var infoJson = JsonSerializer.Serialize(info);
+            File.WriteAllText("info.json", infoJson);
+            CreateEntry(archive, "info.json", Path.GetFileName("info.json"));
+
+            return mpakPath;
         }
 
         void CreateEntry(ZipArchive archive, string fromFile, string entryPath)

--- a/Meadow.CLI.Core/Managers/PackageManager.cs
+++ b/Meadow.CLI.Core/Managers/PackageManager.cs
@@ -145,7 +145,11 @@ namespace Meadow.CLI.Core
             }
 
             // write a metadata file info.json in the mpak
-            var info = new { v = 1, osVersion };
+            PackageInfo info = new PackageInfo()
+            {
+                Version = "1",
+                OsVersion = osVersion
+            };
             var infoJson = JsonSerializer.Serialize(info);
             File.WriteAllText(_info_json, infoJson);
             CreateEntry(archive, _info_json, Path.GetFileName(_info_json));

--- a/Meadow.CLI.Core/Managers/PackageManager.cs
+++ b/Meadow.CLI.Core/Managers/PackageManager.cs
@@ -114,12 +114,13 @@ namespace Meadow.CLI.Core
 
             if (File.Exists(mpakPath))
             {
-                Console.WriteLine($"{mpakPath} already exists. Do you with to overwrite (Y/n)");
+                Console.WriteLine($"{mpakPath} already exists. Do you wish to overwrite? (Y/n)");
 
                 while (true)
                 {
                     Console.Write("> ");
                     var input = Console.ReadKey();
+                    Console.WriteLine();
                     switch (input.Key)
                     {
                         case ConsoleKey.Y:

--- a/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="CredentialManagement.Standard" Version="1.0.4" />
+    <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.3" />

--- a/Meadow.CLI.Core/Meadow.CLI.Core.Classic.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.Classic.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <PackageReference Include="CredentialManagement.Standard" Version="1.0.4" />
+    <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.5" />

--- a/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
@@ -43,6 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="CredentialManagement.Standard" Version="1.0.4" />
+    <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
     <PackageReference Include="LibUsbDotNet" Version="3.0.102-alpha" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/Meadow.CLI.Core/Meadow.CLI.Core.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="CredentialManagement.Standard" Version="1.0.4" />
+    <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
     <PackageReference Include="LibUsbDotNet" Version="3.0.102-alpha" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/Meadow.CLI.Core/PackageInfo.cs
+++ b/Meadow.CLI.Core/PackageInfo.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Meadow.CLI.Core;
+
+public class PackageInfo
+{
+    [JsonPropertyName("v")] 
+    public string Version { get; set; }
+    [JsonPropertyName("osVersion")] 
+    public string OsVersion { get; set; }
+}

--- a/Meadow.CLI/Commands/Cloud/Package/CreatePackageCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/CreatePackageCommand.cs
@@ -38,7 +38,7 @@ namespace Meadow.CLI.Commands.Cloud
 
         [CommandOption("filter", 'f', Description = "Glob pattern to filter files. ex ('app.dll', 'app*','{app.dll,meadow.dll}')",
             IsRequired = false)]
-        public string FilesToInclude { get; init; } = "*";
+        public string Filter { get; init; } = "*";
 
         public async ValueTask ExecuteAsync(IConsole console)
         {
@@ -48,7 +48,7 @@ namespace Meadow.CLI.Commands.Cloud
 
             try
             {
-                var mpak = await _packageManager.CreatePackage(ProjectPath, OsVersion, MpakName, FilesToInclude);
+                var mpak = await _packageManager.CreatePackage(ProjectPath, OsVersion, MpakName, Filter);
                 if (!string.IsNullOrEmpty(mpak))
                 {
                     _logger.LogInformation($"{mpak} created.");

--- a/Meadow.CLI/Commands/Cloud/Package/CreatePackageCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/CreatePackageCommand.cs
@@ -36,9 +36,9 @@ namespace Meadow.CLI.Commands.Cloud
         [CommandOption("name", 'n', Description = "Name of the mpak file to be created", IsRequired = false)]
         public string MpakName { get; init; } = default!;
 
-        [CommandOption("files", 'f', Description = "Files to include in mpak (glob path). Default is all.",
+        [CommandOption("filter", 'f', Description = "Glob pattern to filter files. ex ('app.dll', 'app*','{app.dll,meadow.dll}')",
             IsRequired = false)]
-        public string FilesToInclude { get; init; } = "**";
+        public string FilesToInclude { get; init; } = "*";
 
         public async ValueTask ExecuteAsync(IConsole console)
         {

--- a/Meadow.CLI/Commands/Cloud/Package/CreatePackageCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Package/CreatePackageCommand.cs
@@ -26,12 +26,19 @@ namespace Meadow.CLI.Commands.Cloud
             _packageManager = packageManager;
         }
 
-        [CommandOption("applicationPath", 'a', Description = "The path to the application directory", IsRequired = false)]
-        public string ApplicationPath { get; init; }
+        [CommandOption("projectFilePath", 'p', Description = "The path to the project file (ie .csproj)",
+            IsRequired = true)]
+        public string ProjectPath { get; init; } = default!;
 
-        [CommandOption("osVersion", 'v', Description = "Version of Meadow OS to include in package", IsRequired = false)]
-        public string OsVersion { get; init; }
+        [CommandOption("osVersion", 'v', Description = "Target OS version for the app", IsRequired = true)]
+        public string OsVersion { get; init; } = default!;
 
+        [CommandOption("name", 'n', Description = "Name of the mpak file to be created", IsRequired = false)]
+        public string MpakName { get; init; } = default!;
+
+        [CommandOption("files", 'f', Description = "Files to include in mpak (glob path). Default is all.",
+            IsRequired = false)]
+        public string FilesToInclude { get; init; } = "**";
 
         public async ValueTask ExecuteAsync(IConsole console)
         {
@@ -41,13 +48,13 @@ namespace Meadow.CLI.Commands.Cloud
 
             try
             {
-                var zipFile = _packageManager.CreatePackage(ApplicationPath, OsVersion);
-                if(!string.IsNullOrEmpty(zipFile))
+                var mpak = await _packageManager.CreatePackage(ProjectPath, OsVersion, MpakName, FilesToInclude);
+                if (!string.IsNullOrEmpty(mpak))
                 {
-                    _logger.LogInformation($"{zipFile} created.");
-                }           
+                    _logger.LogInformation($"{mpak} created.");
+                }
             }
-            catch(ArgumentException ex)
+            catch (ArgumentException ex)
             {
                 _logger.LogError(ex.Message);
             }

--- a/Meadow.CLI/Properties/launchSettings.json
+++ b/Meadow.CLI/Properties/launchSettings.json
@@ -90,7 +90,7 @@
     },
     "Package Upload": {
       "commandName": "Project",
-      "commandLineArgs": "package upload -p 20230314363.mpak"
+      "commandLineArgs": "package upload -p awesome_app.mpak -o 5b1d2b0dab744a04b79b245d881e18b8 --host https://staging.meadowcloud.dev"
     },
     "Collection List": {
       "commandName": "Project",

--- a/Meadow.CLI/Properties/launchSettings.json
+++ b/Meadow.CLI/Properties/launchSettings.json
@@ -78,7 +78,7 @@
     },
     "Package Create": {
       "commandName": "Project",
-      "commandLineArgs": "package create -p /Users/briankim/gh/OtaSample/OtaSample.csproj -v 1.2.0.1 -n awesome_app -f {app.dll}" 
+      "commandLineArgs": "package create -p /Users/briankim/gh/OtaSample/OtaSample.csproj -v 1.2.0.1" 
     },
     "Package List": {
       "commandName": "Project",
@@ -90,7 +90,7 @@
     },
     "Package Upload": {
       "commandName": "Project",
-      "commandLineArgs": "package upload -p awesome_app.mpak -o 5b1d2b0dab744a04b79b245d881e18b8 --host https://staging.meadowcloud.dev"
+      "commandLineArgs": "package upload -p awesome_app.mpak -o 5b1d2b0dab744a04b79b245d881e18b8"
     },
     "Collection List": {
       "commandName": "Project",

--- a/Meadow.CLI/Properties/launchSettings.json
+++ b/Meadow.CLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "AppDeploy": {
       "commandName": "Project",
-      "commandLineArgs": "app deploy -f C:\\WL\\Meadow.Core.Samples\\Source\\Meadow.Core.Samples\\Blinky\\BlinkyCS\\bin\\Debug\\netstandard2.1\\App.dll -s COM3"
+      "commandLineArgs": "app deploy -f /Users/briankim/gh/OtaSample/bin/Debug/netstandard2.1/App.dll"
     },
     "CloudLogin": {
       "commandName": "Project",
@@ -78,7 +78,7 @@
     },
     "Package Create": {
       "commandName": "Project",
-      "commandLineArgs": "package create -v 1.0.0.0"
+      "commandLineArgs": "package create -p /Users/briankim/gh/OtaSample/OtaSample.csproj -v 1.2.0.1" 
     },
     "Package List": {
       "commandName": "Project",

--- a/Meadow.CLI/Properties/launchSettings.json
+++ b/Meadow.CLI/Properties/launchSettings.json
@@ -78,7 +78,7 @@
     },
     "Package Create": {
       "commandName": "Project",
-      "commandLineArgs": "package create -p /Users/briankim/gh/OtaSample/OtaSample.csproj -v 1.2.0.1" 
+      "commandLineArgs": "package create -p /Users/briankim/gh/OtaSample/OtaSample.csproj -v 1.2.0.1 -n awesome_app -f {app.dll}" 
     },
     "Package List": {
       "commandName": "Project",


### PR DESCRIPTION
updates for `meadow package create`:
* ability to create meadow package with project file (instead of project path)
  * additionally, build project and trim dependencies :tada:
  * implement verbose flag when trimming dependencies
* ability to specify mpak filename using `--name` (will prompt for overwrite if file already exists)
* ability to filter files when creating mpak with `--filter` and glob pattern
* require `osVersion` when creating package and add as metadata in `info.json` file within mpak

```
USAGE
  meadow package create --projectFilePath <value> --osVersion <value> [options]

DESCRIPTION
  Create Meadow Package

OPTIONS
* -p|--projectFilePath  The path to the project file (ie .csproj) 
* -v|--osVersion    Target OS version for the app 
  -n|--name         Name of the mpak file to be created 
  -f|--filter       Glob pattern to filter files. ex ('app.dll', 'app*','{app.dll,meadow.dll}') Default: "*".
  -h|--help         Shows help text. 
```
mpak structure and `info.json` contents:
<img width="449" alt="image" src="https://github.com/WildernessLabs/Meadow.CLI/assets/1048330/b6a26013-427d-43fd-a219-bf1268e202ff">

updates for `meadow package upload`:
* on package upload, extract `osVersion` from `info.json` and include in API payload