### PR TITLE
Add ability to publish commands to devices by device ID via Meadow.Cloud

### DIFF
--- a/Meadow.CLI.Core/CloudServices/CommandService.cs
+++ b/Meadow.CLI.Core/CloudServices/CommandService.cs
@@ -50,5 +50,37 @@ namespace Meadow.CLI.Core.CloudServices
                 throw new MeadowCloudException(message);
             }
         }
+
+        public async Task PublishCommandForDevices(
+            string[] deviceIds,
+            string commandName,
+            JsonDocument? arguments = null,
+            int qualityOfService = 0,
+            string? host = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(host))
+            {
+                host = _config[Constants.MEADOW_CLOUD_HOST_CONFIG_NAME];
+            }
+
+            var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
+
+            var payload = new
+            {
+                deviceIds,
+                commandName,
+                args = arguments,
+                qos = qualityOfService
+            };
+            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            var response = await httpClient.PostAsync($"{host}/api/devices/commands", content, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var message = await response.Content.ReadAsStringAsync();
+                throw new MeadowCloudException(message);
+            }
+        }
     }
 }

--- a/Meadow.CLI/Commands/Cloud/Command/PublishCommand.cs
+++ b/Meadow.CLI/Commands/Cloud/Command/PublishCommand.cs
@@ -7,6 +7,7 @@ using Meadow.CLI.Core.Exceptions;
 using Meadow.CLI.Core.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -38,8 +39,11 @@ namespace Meadow.CLI.Commands.Cloud.Command
         [CommandParameter(0, Description = "The name of the command", IsRequired = true, Name = "COMMAND_NAME")]
         public string CommandName { get; set; }
 
-        [CommandOption("collectionId", 'c', Description = "The target collection for publishing the command", IsRequired = true)]
+        [CommandOption("collectionId", 'c', Description = "The target collection for publishing the command")]
         public string CollectionId { get; set; }
+
+        [CommandOption("deviceIds", 'd', Description = "The target devices for publishing the command")]
+        public string[] DeviceIds { get; set; }
 
         [CommandOption("args", 'a', Description = "The arguments for the command as a JSON string", Converter = typeof(JsonDocumentBindingConverter))]
         public JsonDocument Arguments { get; set; }
@@ -52,6 +56,16 @@ namespace Meadow.CLI.Commands.Cloud.Command
 
         public async ValueTask ExecuteAsync(IConsole console)
         {
+            if (string.IsNullOrWhiteSpace(CollectionId) && (DeviceIds == null || DeviceIds.Length == 0))
+            {
+                throw new CommandException("Either a collection ID (-c|--collectionId) or a list of device IDs (-d|--deviceIds) must be specified.", showHelp: true);
+            }
+
+            if (!string.IsNullOrWhiteSpace(CollectionId) && (DeviceIds != null && DeviceIds.Length > 0))
+            {
+                throw new CommandException("Cannot specify both a collection ID (-c|--collectionId) and list of device IDs (-d|--deviceIds). Only one is allowed.", showHelp: true);
+            }
+
             var cancellationToken = console.RegisterCancellationHandler();
 
             await Task.Yield();
@@ -65,7 +79,18 @@ namespace Meadow.CLI.Commands.Cloud.Command
             try
             {
                 _logger.LogInformation($"Publishing '{CommandName}' command to Meadow.Cloud. Please wait...");
-                await _commandService.PublishCommandForCollection(CollectionId, CommandName, Arguments, (int)QualityOfService, Host, cancellationToken);
+                if (!string.IsNullOrWhiteSpace(CollectionId))
+                {
+                    await _commandService.PublishCommandForCollection(CollectionId, CommandName, Arguments, (int)QualityOfService, Host, cancellationToken);
+                }
+                else if (DeviceIds.Any())
+                {
+                    await _commandService.PublishCommandForDevices(DeviceIds, CommandName, Arguments, (int)QualityOfService, Host, cancellationToken);
+                }
+                else
+                {
+                    throw new CommandException("Cannot specify both a collection ID (-c|--collectionId) and list of device IDs (-d|--deviceIds). Only one is allowed.");
+                }
                 _logger.LogInformation("Publish command successful.");
             }
             catch (MeadowCloudAuthException ex)


### PR DESCRIPTION
This updates the ability to publish commands to a collection of devices via Meadow.Cloud by including the the ability to specify devices by their device ID. The update command is `meadow cloud command publish <COMMAND_NAME> --deviceIds <a list of device ids>`. The generated help text for this new command is:

```
USAGE
  meadow cloud command publish <COMMAND_NAME> [options]

DESCRIPTION
  Publish a command to Meadow devices via the Meadow Service

PARAMETERS
* COMMAND_NAME      The name of the command

OPTIONS
  -c|--collectionId  The target collection for publishing the command
  -d|--deviceIds    The target devices for publishing the command
  -a|--args         The arguments for the command as a JSON string
  -q|--qos          The MQTT-defined quality of service for the command Choices: "AtLeastOnce", "AtMostOnce", "ExactlyOnce". Default: "AtLeastOnce".
  --host            Optionally set a host (default is https://www.meadowcloud.co)
  -h|--help         Shows help text.
```

With this update, `meadow cloud command publish` can either take in a `collectionId` or a list of `deviceIds`.

## Example

An example of this command would be:

```
C:\>meadow login
Signed in as user@example.org
Done!

C:\>meadow cloud command publish TurnOnWater -d example_device_id1 example_device_id2 -a "{""durationInMinutes"":15}"
Publishing 'TurnOnWater ' command to Meadow.Cloud. Please wait...
Publish command successful.
Done!
```

If the included arguments are not properly formatted (quotes need to be escaped), a JSON error will occur:

```
C:\>meadow cloud command publish TurnOnWater -d example_device_id1 example_device_id2 -a "{"duration":15}"
Provided arguments is not valid JSON: 'd' is an invalid start of a property name. Expected a '"'. LineNumber: 0 | BytePositionInLine: 1.
Done!
```

If neither a collection ID nor device IDs are specified:

```
C:\>meadow cloud command publish TurnOnWater 
Either a collection ID (-c|--collectionId) or a list of device IDs (-d|--deviceIds) must be specified.

...more...
```

If **both** collection ID and device IDs are specified:

```
C:\>meadow cloud command publish TurnOnWater -c example_collection_id -d example_device_id1 example_device_id2
Cannot specify both a collection ID (-c|--collectionId) and list of device IDs (-d|--deviceIds). Only one is allowed.

...more...
```