### PR TITLE
Version bump to 1.3.0.0

### DIFF
--- a/Meadow.CLI.Core/Constants.cs
+++ b/Meadow.CLI.Core/Constants.cs
@@ -7,7 +7,7 @@ namespace Meadow.CLI.Core
 {
     public static class Constants
     {
-        public const string CLI_VERSION = "1.2.2.0";
+        public const string CLI_VERSION = "1.3.0.0";
         public const ushort HCOM_PROTOCOL_PREVIOUS_VERSION_NUMBER = 0x0006;
         public const ushort HCOM_PROTOCOL_CURRENT_VERSION_NUMBER = 0x0007;         // Used for transmission
         public const string WILDERNESS_LABS_USB_VID = "2E6A";

--- a/Meadow.CLI/Meadow.CLI.Classic.csproj
+++ b/Meadow.CLI/Meadow.CLI.Classic.csproj
@@ -23,7 +23,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <AssemblyName>meadow</AssemblyName>
 	<LangVersion>latest</LangVersion>
-	<Copyright>Copyright 2020-2022 Wilderness Labs</Copyright>
+	<Copyright>Copyright 2020-2023 Wilderness Labs</Copyright>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Meadow.CLI/Meadow.CLI.csproj
+++ b/Meadow.CLI/Meadow.CLI.csproj
@@ -23,7 +23,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <AssemblyName>meadow</AssemblyName>
 	<LangVersion>latest</LangVersion>
-	<Copyright>Copyright 2020-2022 Wilderness Labs</Copyright>
+	<Copyright>Copyright 2020-2023 Wilderness Labs</Copyright>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After installing the latest CLI from here, I was still getting v1.2.2.
https://github.com/WildernessLabs/Meadow.CLI/actions/runs/5972170825

Hopefully this fixes that.

Also merged in #346 for one PR.