### PR TITLE
Refactor to support port list without connection and with console int…

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 [Command("app build", Description = "Compiles a Meadow application")]
-public class AppBuildCommand : BaseSettingsCommand<AppBuildCommand>
+public class AppBuildCommand : BaseCommand<AppBuildCommand>
 {
     private IPackageManager _packageManager;
 
@@ -17,13 +17,13 @@ public class AppBuildCommand : BaseSettingsCommand<AppBuildCommand>
     [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
     public string? Path { get; set; } = default!;
 
-    public AppBuildCommand(IPackageManager packageManager, ISettingsManager settingsManager, ILoggerFactory loggerFactory)
-        : base(settingsManager, loggerFactory)
+    public AppBuildCommand(IPackageManager packageManager, ILoggerFactory loggerFactory)
+        : base(loggerFactory)
     {
         _packageManager = packageManager;
     }
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
         string path = Path == null
             ? AppDomain.CurrentDomain.BaseDirectory

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
@@ -1,11 +1,13 @@
 ﻿using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Meadow.Cli;
+using Meadow.Hcom;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 [Command("app build", Description = "Compiles a Meadow application")]
-public class AppBuildCommand : BaseCommand<AppBuildCommand>
+public class AppBuildCommand : BaseSettingsCommand<AppBuildCommand>
 {
     private IPackageManager _packageManager;
 
@@ -21,7 +23,7 @@ public class AppBuildCommand : BaseCommand<AppBuildCommand>
         _packageManager = packageManager;
     }
 
-    protected override async ValueTask ExecuteCommand(CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
         string path = Path == null
             ? AppDomain.CurrentDomain.BaseDirectory
@@ -33,25 +35,25 @@ public class AppBuildCommand : BaseCommand<AppBuildCommand>
             // is it a valid directory?
             if (!Directory.Exists(path))
             {
-                Logger.LogError($"Invalid application path '{path}'");
+                Logger?.LogError($"Invalid application path '{path}'");
                 return;
             }
         }
 
         if (Configuration == null) Configuration = "Release";
 
-        Logger.LogInformation($"Building {Configuration} configuration of {path}...");
+        Logger?.LogInformation($"Building {Configuration} configuration of {path}...");
 
         // TODO: enable cancellation of this call
         var success = _packageManager.BuildApplication(path, Configuration);
 
         if (!success)
         {
-            Logger.LogError($"Build failed!");
+            Logger?.LogError($"Build failed!");
         }
         else
         {
-            Logger.LogError($"Build success.");
+            Logger?.LogError($"Build success.");
         }
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
@@ -1,4 +1,5 @@
 ﻿using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Meadow.Cli;
 using Meadow.Hcom;
 using Microsoft.Extensions.Logging;

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 [Command("app trim", Description = "Runs an already-compiled Meadow application through reference trimming")]
-public class AppTrimCommand : BaseSettingsCommand<AppTrimCommand>
+public class AppTrimCommand : BaseCommand<AppTrimCommand>
 {
     private IPackageManager _packageManager;
 
@@ -16,13 +16,13 @@ public class AppTrimCommand : BaseSettingsCommand<AppTrimCommand>
     [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
     public string? Path { get; set; } = default!;
 
-    public AppTrimCommand(IPackageManager packageManager, ISettingsManager settingsManager, ILoggerFactory loggerFactory)
-        : base(settingsManager, loggerFactory)
+    public AppTrimCommand(IPackageManager packageManager, ILoggerFactory loggerFactory)
+        : base(loggerFactory)
     {
         _packageManager = packageManager;
     }
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
         string path = Path == null
             ? AppDomain.CurrentDomain.BaseDirectory
@@ -59,6 +59,6 @@ public class AppTrimCommand : BaseSettingsCommand<AppTrimCommand>
         // if no configuration was provided, find the most recently built
         Logger?.LogInformation($"Trimming {file.FullName} (this may take a few seconds)...");
 
-        await _packageManager.TrimApplication(file, false, null, cancellationToken);
+        await _packageManager.TrimApplication(file, false, null, cancellationToken ?? default);
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
@@ -1,11 +1,12 @@
 ﻿using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Meadow.Cli;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 [Command("app trim", Description = "Runs an already-compiled Meadow application through reference trimming")]
-public class AppTrimCommand : BaseCommand<AppTrimCommand>
+public class AppTrimCommand : BaseSettingsCommand<AppTrimCommand>
 {
     private IPackageManager _packageManager;
 
@@ -21,7 +22,7 @@ public class AppTrimCommand : BaseCommand<AppTrimCommand>
         _packageManager = packageManager;
     }
 
-    protected override async ValueTask ExecuteCommand(CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
         string path = Path == null
             ? AppDomain.CurrentDomain.BaseDirectory
@@ -35,7 +36,7 @@ public class AppTrimCommand : BaseCommand<AppTrimCommand>
             // is it a valid directory?
             if (!Directory.Exists(path))
             {
-                Logger.LogError($"Invalid application path '{path}'");
+                Logger?.LogError($"Invalid application path '{path}'");
                 return;
             }
 
@@ -44,7 +45,7 @@ public class AppTrimCommand : BaseCommand<AppTrimCommand>
 
             if (candidates.Length == 0)
             {
-                Logger.LogError($"Cannot find a compiled application at '{path}'");
+                Logger?.LogError($"Cannot find a compiled application at '{path}'");
                 return;
             }
 
@@ -56,7 +57,7 @@ public class AppTrimCommand : BaseCommand<AppTrimCommand>
         }
 
         // if no configuration was provided, find the most recently built
-        Logger.LogInformation($"Trimming {file.FullName} (this may take a few seconds)...");
+        Logger?.LogInformation($"Trimming {file.FullName} (this may take a few seconds)...");
 
         await _packageManager.TrimApplication(file, false, null, cancellationToken);
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
@@ -1,22 +1,22 @@
 ﻿using CliFx;
 using CliFx.Infrastructure;
-using Meadow.Cli;
+using Meadow.Hcom;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 public abstract class BaseCommand<T> : ICommand
 {
-    protected ILogger<T> Logger { get; }
-    protected ISettingsManager SettingsManager { get; }
+    protected ILogger<T>? Logger { get; }
+    protected ILoggerFactory? LoggerFactory { get; }
 
-    public BaseCommand(ISettingsManager settingsManager, ILoggerFactory loggerFactory)
+    public BaseCommand(ILoggerFactory? loggerFactory)
     {
-        Logger = loggerFactory.CreateLogger<T>();
-        SettingsManager = settingsManager;
+        LoggerFactory = loggerFactory;
+        Logger = loggerFactory?.CreateLogger<T>();
     }
 
-    protected abstract ValueTask ExecuteCommand(CancellationToken cancellationToken);
+    protected abstract ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken);
 
     public virtual async ValueTask ExecuteAsync(IConsole console)
     {
@@ -24,11 +24,11 @@ public abstract class BaseCommand<T> : ICommand
 
         try
         {
-            await ExecuteCommand(cancellationToken);
+            await ExecuteCommand(console, cancellationToken);
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex.Message);
+            Logger?.LogError(ex.Message);
         }
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
@@ -9,6 +9,7 @@ public abstract class BaseCommand<T> : ICommand
 {
     protected ILogger<T>? Logger { get; }
     protected ILoggerFactory? LoggerFactory { get; }
+    protected IConsole? Console { get; private set; }
 
     public BaseCommand(ILoggerFactory? loggerFactory)
     {
@@ -16,15 +17,17 @@ public abstract class BaseCommand<T> : ICommand
         Logger = loggerFactory?.CreateLogger<T>();
     }
 
-    protected abstract ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken);
+    protected abstract ValueTask ExecuteCommand(CancellationToken? cancellationToken);
 
     public virtual async ValueTask ExecuteAsync(IConsole console)
     {
-        var cancellationToken = console.RegisterCancellationHandler();
+        Console = console;
+        var cancellationToken = Console?.RegisterCancellationHandler();
 
         try
         {
-            await ExecuteCommand(console, cancellationToken);
+            if (cancellationToken!= null)
+                await ExecuteCommand(cancellationToken);
         }
         catch (Exception ex)
         {

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseFileCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseFileCommand.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
-public abstract class BaseFileCommand<T> : BaseCommand<T>
+public abstract class BaseFileCommand<T> : BaseSettingsCommand<T>
 {
     protected FileManager FileManager { get; }
 

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseSettingsCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseSettingsCommand.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Cli;
+﻿using CliFx.Infrastructure;
+using Meadow.Cli;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
@@ -7,7 +8,8 @@ public abstract class BaseSettingsCommand<T> : BaseCommand<T>
 {
     protected ISettingsManager SettingsManager { get; }
 
-    public BaseSettingsCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory) : base(loggerFactory)
+    public BaseSettingsCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory)
+        : base (loggerFactory)
     {
         SettingsManager = settingsManager;
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseSettingsCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseSettingsCommand.cs
@@ -1,0 +1,14 @@
+﻿using Meadow.Cli;
+using Microsoft.Extensions.Logging;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+public abstract class BaseSettingsCommand<T> : BaseCommand<T>
+{
+    protected ISettingsManager SettingsManager { get; }
+
+    public BaseSettingsCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory) : base(loggerFactory)
+    {
+        SettingsManager = settingsManager;
+    }
+}

--- a/Source/v2/Meadow.Cli/Commands/Current/ConfigCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/ConfigCommand.cs
@@ -8,40 +8,36 @@ using Microsoft.Extensions.Logging;
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 [Command("config", Description = "Read or modify the meadow CLI configuration")]
-public class ConfigCommand : ICommand
+public class ConfigCommand : BaseSettingsCommand<ConfigCommand>
 {
-    private readonly ISettingsManager _settingsManager;
-    private readonly ILogger<DeviceInfoCommand>? _logger;
-
     [CommandOption("list", IsRequired = false)]
     public bool List { get; set; }
 
     [CommandParameter(0, Name = "Settings", IsRequired = false)]
     public string[] Settings { get; set; }
 
-    public ConfigCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory)
+    public ConfigCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory) : base(settingsManager, loggerFactory)
     {
-        _logger = loggerFactory?.CreateLogger<DeviceInfoCommand>();
-        _settingsManager = settingsManager;
+        
     }
 
-    public async ValueTask ExecuteAsync(IConsole console)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
         if (List)
         {
-            _logger?.LogInformation($"Current CLI configuration");
+            Logger?.LogInformation($"Current CLI configuration");
 
             // display all current config
-            var settings = _settingsManager.GetPublicSettings();
+            var settings = SettingsManager.GetPublicSettings();
             if (settings.Count == 0)
             {
-                _logger?.LogInformation($"  <no settings found>");
+                Logger?.LogInformation($"  <no settings found>");
             }
             else
             {
-                foreach (var kvp in _settingsManager.GetPublicSettings())
+                foreach (var kvp in SettingsManager.GetPublicSettings())
                 {
-                    _logger?.LogInformation($"  {kvp.Key} = {kvp.Value}");
+                    Logger?.LogInformation($"  {kvp.Key} = {kvp.Value}");
                 }
             }
         }
@@ -54,13 +50,13 @@ public class ConfigCommand : ICommand
                     throw new CommandException($"No setting provided");
                 case 1:
                     // erase a setting
-                    _logger?.LogInformation($"Deleting Setting {Settings[0]}");
-                    _settingsManager.DeleteSetting(Settings[0]);
+                    Logger?.LogInformation($"Deleting Setting {Settings[0]}");
+                    SettingsManager.DeleteSetting(Settings[0]);
                     break;
                 case 2:
                     // set a setting
-                    _logger?.LogInformation($"Setting {Settings[0]}={Settings[1]}");
-                    _settingsManager.SaveSetting(Settings[0], Settings[1]);
+                    Logger?.LogInformation($"Setting {Settings[0]}={Settings[1]}");
+                    SettingsManager.SaveSetting(Settings[0], Settings[1]);
                     break;
                 default:
                     // not valid;

--- a/Source/v2/Meadow.Cli/Commands/Current/ConfigCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/ConfigCommand.cs
@@ -14,14 +14,15 @@ public class ConfigCommand : BaseSettingsCommand<ConfigCommand>
     public bool List { get; set; }
 
     [CommandParameter(0, Name = "Settings", IsRequired = false)]
-    public string[] Settings { get; set; }
+    public string[]? Settings { get; set; }
 
-    public ConfigCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory) : base(settingsManager, loggerFactory)
+    public ConfigCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory)
+        : base(settingsManager, loggerFactory)
     {
         
     }
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
         if (List)
         {
@@ -43,19 +44,19 @@ public class ConfigCommand : BaseSettingsCommand<ConfigCommand>
         }
         else
         {
-            switch (Settings.Length)
+            switch (Settings?.Length)
             {
                 case 0:
                     // not valid
                     throw new CommandException($"No setting provided");
                 case 1:
                     // erase a setting
-                    Logger?.LogInformation($"Deleting Setting {Settings[0]}");
+                    Logger?.LogInformation($"{Environment.NewLine}Deleting Setting {Settings[0]}");
                     SettingsManager.DeleteSetting(Settings[0]);
                     break;
                 case 2:
                     // set a setting
-                    Logger?.LogInformation($"Setting {Settings[0]}={Settings[1]}");
+                    Logger?.LogInformation($"{Environment.NewLine}Setting {Settings[0]}={Settings[1]}");
                     SettingsManager.SaveSetting(Settings[0], Settings[1]);
                     break;
                 default:

--- a/Source/v2/Meadow.Cli/Commands/Current/Dfu/DfuInstallCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Dfu/DfuInstallCommand.cs
@@ -29,7 +29,7 @@ public class DfuInstallCommand : BaseSettingsCommand<AppDeployCommand>
     {
     }
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
         if (Version == null)
         {
@@ -43,7 +43,7 @@ public class DfuInstallCommand : BaseSettingsCommand<AppDeployCommand>
                 // valid
                 break;
             default:
-                Logger.LogError("Only versions 0.10 and 0.11 are supported.");
+                Logger?.LogError("Only versions 0.10 and 0.11 are supported.");
                 return;
         }
 
@@ -51,20 +51,20 @@ public class DfuInstallCommand : BaseSettingsCommand<AppDeployCommand>
         {
             if (IsAdministrator())
             {
-                await DfuUtils.InstallDfuUtil(FileManager.WildernessTempFolderPath, Version, cancellationToken);
+                await DfuUtils.InstallDfuUtil(FileManager.WildernessTempFolderPath, Version, cancellationToken ?? default);
             }
             else
             {
-                Logger.LogError("To install DFU on Windows, you'll need to re-run the command from as an Administrator");
+                Logger?.LogError("To install DFU on Windows, you'll need to re-run the command from as an Administrator");
             }
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            Logger.LogWarning("To install DFU on macOS, run: brew install dfu-util");
+            Logger?.LogWarning("To install DFU on macOS, run: brew install dfu-util");
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            Logger.LogWarning(
+            Logger?.LogWarning(
                 "To install DFU on Linux, use the package manager to install the dfu-util package");
         }
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/Dfu/DfuInstallCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Dfu/DfuInstallCommand.cs
@@ -1,6 +1,8 @@
 ﻿using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Meadow.Cli;
 using Meadow.CLI.Core.Internals.Dfu;
+using Meadow.Hcom;
 using Meadow.Software;
 using Microsoft.Extensions.Logging;
 using System.Runtime.InteropServices;
@@ -9,7 +11,7 @@ using System.Security.Principal;
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 [Command("dfu install", Description = "Deploys a built Meadow application to a target device")]
-public class DfuInstallCommand : BaseCommand<AppDeployCommand>
+public class DfuInstallCommand : BaseSettingsCommand<AppDeployCommand>
 {
     public const string DefaultVersion = "0.11";
 
@@ -27,7 +29,7 @@ public class DfuInstallCommand : BaseCommand<AppDeployCommand>
     {
     }
 
-    protected override async ValueTask ExecuteCommand(CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
         if (Version == null)
         {

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
@@ -1,5 +1,7 @@
 ﻿using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Meadow.Cli;
+using Meadow.Hcom;
 using Meadow.Software;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +18,7 @@ public class FirmwareDefaultCommand : BaseFileCommand<FirmwareDefaultCommand>
     [CommandParameter(0, Name = "Version number to use as default", IsRequired = true)]
     public string Version { get; set; } = default!;
 
-    protected override async ValueTask ExecuteCommand(CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
         await FileManager.Refresh();
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
@@ -18,7 +18,7 @@ public class FirmwareDefaultCommand : BaseFileCommand<FirmwareDefaultCommand>
     [CommandParameter(0, Name = "Version number to use as default", IsRequired = true)]
     public string Version { get; set; } = default!;
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
         await FileManager.Refresh();
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
@@ -1,5 +1,7 @@
 ﻿using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Meadow.Cli;
+using Meadow.Hcom;
 using Meadow.Software;
 using Microsoft.Extensions.Logging;
 
@@ -16,7 +18,7 @@ public class FirmwareDeleteCommand : BaseFileCommand<FirmwareDeleteCommand>
     [CommandParameter(0, Name = "Version number to delete", IsRequired = true)]
     public string Version { get; set; } = default!;
 
-    protected override async ValueTask ExecuteCommand(CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
         await FileManager.Refresh();
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
@@ -18,7 +18,7 @@ public class FirmwareDeleteCommand : BaseFileCommand<FirmwareDeleteCommand>
     [CommandParameter(0, Name = "Version number to delete", IsRequired = true)]
     public string Version { get; set; } = default!;
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
         await FileManager.Refresh();
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
@@ -21,7 +21,7 @@ public class FirmwareDownloadCommand : BaseFileCommand<FirmwareDownloadCommand>
     [CommandParameter(0, Name = "Version number to download", IsRequired = false)]
     public string? Version { get; set; } = default!;
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
         await FileManager.Refresh();
 
@@ -81,6 +81,6 @@ public class FirmwareDownloadCommand : BaseFileCommand<FirmwareDownloadCommand>
 
     private void OnDownloadProgress(object? sender, long e)
     {
-        Console.Write($"Retrieved {e} bytes...                    \r");
+        Logger?.LogInformation($"Retrieved {e} bytes...                    \r");
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
@@ -1,5 +1,7 @@
 ﻿using CliFx.Attributes;
+using CliFx.Infrastructure;
 using Meadow.Cli;
+using Meadow.Hcom;
 using Meadow.Software;
 using Microsoft.Extensions.Logging;
 
@@ -19,7 +21,7 @@ public class FirmwareDownloadCommand : BaseFileCommand<FirmwareDownloadCommand>
     [CommandParameter(0, Name = "Version number to download", IsRequired = false)]
     public string? Version { get; set; } = default!;
 
-    protected override async ValueTask ExecuteCommand(CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
         await FileManager.Refresh();
 

--- a/Source/v2/Meadow.Cli/Commands/Current/PortListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/PortListCommand.cs
@@ -1,22 +1,42 @@
-﻿using CliFx.Attributes;
+﻿using System;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+using Meadow.Cli;
+using Meadow.Hardware;
 using Meadow.Hcom;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
 [Command("port list", Description = "List available local serial ports")]
-public class PortListCommand : BaseDeviceCommand<PortListCommand>
+public class PortListCommand : BaseCommand<PortListCommand>
 {
-    public PortListCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
-        : base(connectionManager, loggerFactory)
+    public PortListCommand(ILoggerFactory loggerFactory)
+        : base(loggerFactory)
     {
     }
 
-    protected override async ValueTask ExecuteCommand(IMeadowConnection connection, Hcom.IMeadowDevice device, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
     {
-        foreach (var port in await MeadowConnectionManager.GetSerialPorts())
+        var portlist = await MeadowConnectionManager.GetSerialPorts();
+        for (int i = 0; i < portlist.Count; i++)
         {
-            Logger.LogInformation("Found Meadow: {port}", port);
+            Logger?.LogInformation($"{i + 1}: {portlist[i]}");
+        }
+        Logger?.LogInformation($"{Environment.NewLine}Type the number of the port you would like to use.{Environment.NewLine}or just press Enter to keep your current port.");
+
+        byte deviceSelected;
+        if (byte.TryParse(await console.Input.ReadLineAsync(), out deviceSelected))
+        {
+            if (deviceSelected > 0 && deviceSelected  <= portlist.Count)
+            {
+                var setCommand = new ConfigCommand(new SettingsManager(), LoggerFactory)
+                {
+                    Settings = new string[] { "route", portlist[deviceSelected - 1] }
+                };
+
+                await setCommand.ExecuteAsync(console);
+            }
         }
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/PortListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/PortListCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
-using Meadow.Cli;
 using Meadow.Hardware;
 using Meadow.Hcom;
 using Microsoft.Extensions.Logging;
@@ -11,31 +10,23 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 [Command("port list", Description = "List available local serial ports")]
 public class PortListCommand : BaseCommand<PortListCommand>
 {
+    public IList<string>? Portlist;
+
     public PortListCommand(ILoggerFactory loggerFactory)
         : base(loggerFactory)
     {
     }
 
-    protected override async ValueTask ExecuteCommand(IConsole console, CancellationToken cancellationToken)
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
     {
-        var portlist = await MeadowConnectionManager.GetSerialPorts();
-        for (int i = 0; i < portlist.Count; i++)
+        Portlist = await MeadowConnectionManager.GetSerialPorts();
+        if (Portlist.Count > 0)
         {
-            Logger?.LogInformation($"{i + 1}: {portlist[i]}");
-        }
-        Logger?.LogInformation($"{Environment.NewLine}Type the number of the port you would like to use.{Environment.NewLine}or just press Enter to keep your current port.");
-
-        byte deviceSelected;
-        if (byte.TryParse(await console.Input.ReadLineAsync(), out deviceSelected))
-        {
-            if (deviceSelected > 0 && deviceSelected  <= portlist.Count)
+            var plural = Portlist.Count > 1 ? "s" : string.Empty;
+            Logger?.LogInformation($"Found the following device{plural} -");
+            for (int i = 0; i < Portlist.Count; i++)
             {
-                var setCommand = new ConfigCommand(new SettingsManager(), LoggerFactory)
-                {
-                    Settings = new string[] { "route", portlist[deviceSelected - 1] }
-                };
-
-                await setCommand.ExecuteAsync(console);
+                Logger?.LogInformation($"{i + 1}: {Portlist[i]}");
             }
         }
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/PortSelectCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/PortSelectCommand.cs
@@ -1,0 +1,60 @@
+﻿using CliFx.Attributes;
+using Meadow.Cli;
+using Microsoft.Extensions.Logging;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+[Command("port select", Description = "Select a port from a list of available local serial ports")]
+public class PortSelectCommand : BaseCommand<PortSelectCommand>
+{
+    public PortSelectCommand(ILoggerFactory loggerFactory)
+        : base(loggerFactory)
+    {
+    }
+
+    protected override async ValueTask ExecuteCommand(CancellationToken? cancellationToken)
+    {
+        if (LoggerFactory != null)
+        {
+            if (Console != null)
+            {
+                var portListCommand = new PortListCommand(LoggerFactory);
+
+                await portListCommand.ExecuteAsync(Console);
+
+                if (portListCommand.Portlist?.Count > 0)
+                {
+                    if (portListCommand.Portlist?.Count > 1)
+                    {
+                        Logger?.LogInformation($"{Environment.NewLine}Type the number of the port you would like to use.{Environment.NewLine}or just press Enter to keep your current port.");
+
+                        byte deviceSelected;
+                        if (byte.TryParse(await Console.Input.ReadLineAsync(), out deviceSelected))
+                        {
+                            if (deviceSelected > 0 && deviceSelected <= portListCommand.Portlist?.Count)
+                            {
+                                await CallConfigCommand(portListCommand.Portlist[deviceSelected - 1]);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Only 1 device attached, let's auto select it
+                        if (portListCommand.Portlist != null)
+                            await CallConfigCommand(portListCommand.Portlist[0]);
+                    }
+                }
+            }
+        }
+    }
+
+    private async Task CallConfigCommand(string selectedPort)
+    {
+        var setCommand = new ConfigCommand(new SettingsManager(), LoggerFactory)
+        {
+            Settings = new string[] { "route", selectedPort }
+        };
+
+        await setCommand.ExecuteAsync(Console);
+    }
+}

--- a/Source/v2/Meadow.Cli/DFU/DfuContext.cs
+++ b/Source/v2/Meadow.Cli/DFU/DfuContext.cs
@@ -15,7 +15,7 @@ namespace MeadowCLI
         };
 
         // --------------------------- INSTANCE
-        public static DfuContext Current;
+        public static DfuContext? Current;
 
         public static void Init()
         {
@@ -25,25 +25,32 @@ namespace MeadowCLI
 
         public static void Dispose()
         {
-            Current._context.Dispose();
+            Current?._context?.Dispose();
         }
         // --------------------------- INSTANCE
 
-        private Context _context;
+        private Context? _context;
 
-        public List<DfuDevice> GetDevices()
+        public List<DfuDevice>? GetDevices()
         {
-            return _context.GetDfuDevices(validVendorIDs);
+            if (_context != null)
+                return _context.GetDfuDevices(validVendorIDs);
+            else
+                return null;
         }
 
         public bool HasCapability(Capabilities caps)
         {
-            return _context.HasCapability(caps);
+            if (_context != null)
+                return _context.HasCapability(caps);
+            else
+                return false;
         }
 
         public void BeginListeningForHotplugEvents()
         {
-            _context.BeginListeningForHotplugEvents();
+            if (_context != null)
+                _context.BeginListeningForHotplugEvents();
         }
 
     }

--- a/Source/v2/Meadow.Cli/DFU/DfuUtils.cs
+++ b/Source/v2/Meadow.Cli/DFU/DfuUtils.cs
@@ -75,7 +75,7 @@ public static class DfuUtils
             }
         }
 
-        return serialNumber;
+        return serialNumber ?? string.Empty;
     }
 
     public enum DfuFlashFormat
@@ -318,6 +318,7 @@ public static class DfuUtils
             var downloadUrl = $"https://s3-us-west-2.amazonaws.com/downloads.wildernesslabs.co/public/dfu-util-{dfuUtilVersion}-binaries.zip";
 
             var downloadFileName = downloadUrl.Substring(downloadUrl.LastIndexOf("/", StringComparison.Ordinal) + 1);
+
             var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
             if (response.IsSuccessStatusCode == false)

--- a/Source/v2/Meadow.Cli/PackageManager.AssemblyManager.cs
+++ b/Source/v2/Meadow.Cli/PackageManager.AssemblyManager.cs
@@ -25,8 +25,16 @@ public partial class PackageManager
                 // for now we only support F7
                 // TODO: add switch and support for other platforms
                 var store = _fileManager.Firmware["Meadow F7"];
-                store.Refresh();
-                _meadowAssembliesPath = store.DefaultPackage.GetFullyQualifiedPath(store.DefaultPackage.BclFolder);
+                if (store != null)
+                {
+                    store.Refresh();
+                    if (store.DefaultPackage != null)
+                    {
+                        var defaultPackage = store.DefaultPackage;
+                        if (defaultPackage.BclFolder != null)
+                            _meadowAssembliesPath = defaultPackage.GetFullyQualifiedPath(defaultPackage.BclFolder);
+                    }
+                }
             }
 
             return _meadowAssembliesPath;

--- a/Source/v2/Meadow.Cli/Properties/launchSettings.json
+++ b/Source/v2/Meadow.Cli/Properties/launchSettings.json
@@ -15,6 +15,10 @@
       "commandName": "Project",
       "commandLineArgs": "port list"
     },
+    "Port Select": {
+      "commandName": "Project",
+      "commandLineArgs": "port select"
+    },
     "Listen": {
       "commandName": "Project",
       "commandLineArgs": "listen"

--- a/Source/v2/Meadow.Cli/SettingsManager.cs
+++ b/Source/v2/Meadow.Cli/SettingsManager.cs
@@ -107,9 +107,14 @@ public class SettingsManager : ISettingsManager
     {
         var fi = new FileInfo(Path);
 
-        if (!Directory.Exists(fi.Directory.FullName))
+        var directory = fi.Directory;
+        if (directory != null)
         {
-            Directory.CreateDirectory(fi.Directory.FullName);
+            var directoryFullName = directory?.FullName;
+            if (!string.IsNullOrWhiteSpace(directoryFullName) && !Directory.Exists(directoryFullName))
+            {
+                Directory.CreateDirectory(directoryFullName);
+            }
         }
 
         if (File.Exists(Path))


### PR DESCRIPTION
…eraction.

This refactor will now give us the following output when executing the `port list` command:

```
1: /dev/tty.usbmodem2053317E52301
2: /dev/tty.usbmodem335C317634381
```

Added `port select` command which piggy backs off `port list`: 

```
1: /dev/tty.usbmodem2053317E52301
2: /dev/tty.usbmodem335C317634381

Type the number of the port you would like to use.
or just press Enter to keep your current port.
2

Setting route=/dev/tty.usbmodem335C317634381
```