### PR TITLE
Fix runtime commands on macOS

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
@@ -35,6 +35,7 @@ public class AppDeployCommand : BaseDeviceCommand<AppDeployCommand>
 
             // in order to deploy, the runtime must be disabled
             var wasRuntimeEnabled = await Connection.IsRuntimeEnabled();
+
             if (wasRuntimeEnabled)
             {
                 Logger?.LogInformation("Disabling runtime...");

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
@@ -46,6 +46,7 @@ public class AppRunCommand : BaseDeviceCommand<AppRunCommand>
 
             // in order to deploy, the runtime must be disabled
             var wasRuntimeEnabled = await Connection.IsRuntimeEnabled();
+
             if (wasRuntimeEnabled)
             {
                 Logger?.LogInformation("Disabling runtime...");

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
@@ -34,9 +34,17 @@ public abstract class BaseDeviceCommand<T> : BaseCommand<T>
                 Logger?.LogInformation(message);
             };
 
+            // the connection passes messages back to us (info about actions happening on-device
             connection.DeviceMessageReceived += (s, e) =>
             {
-                Logger?.LogInformation(e.message);
+                if (e.message.Contains("% downloaded"))
+                {
+                    // don't echo this, as we're already reporting % written
+                }
+                else
+                {
+                    Logger?.LogInformation(e.message);
+                }
             };
 
             try

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
@@ -34,7 +34,7 @@ public abstract class BaseDeviceCommand<T> : BaseCommand<T>
                 Logger?.LogInformation(message);
             };
 
-            // the connection passes messages back to us (info about actions happening on-device
+            // the connection passes messages back to us (info about actions happening on-device)
             connection.DeviceMessageReceived += (s, e) =>
             {
                 if (e.message.Contains("% downloaded"))

--- a/Source/v2/Meadow.Cli/Commands/Current/File/FileDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/File/FileDeleteCommand.cs
@@ -58,8 +58,8 @@ public class FileDeleteCommand : BaseDeviceCommand<FileDeleteCommand>
 
                         if (wasRuntimeEnabled)
                         {
-                            Logger?.LogError($"The runtime must be disabled before doing any file management. Use 'meadow runtime disable' first.");
-                            return;
+                            Logger?.LogInformation("Disabling device runtime...");
+                            await Connection.Device.RuntimeDisable();
                         }
 
                         Logger?.LogInformation($"Deleting file '{MeadowFile}' from device...");

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareWriteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareWriteCommand.cs
@@ -236,22 +236,6 @@ public class FirmwareWriteCommand : BaseDeviceCommand<FirmwareWriteCommand>
 
     private async ValueTask WriteFiles(IMeadowConnection connection)
     {
-        // the connection passes messages back to us (info about actions happening on-device
-        connection.DeviceMessageReceived += (s, e) =>
-        {
-            if (e.message.Contains("% downloaded"))
-            {
-                // don't echo this, as we're already reporting % written
-            }
-            else
-            {
-                Logger?.LogInformation(e.message);
-            }
-        };
-        connection.ConnectionMessage += (s, message) =>
-        {
-            Logger?.LogInformation(message);
-        };
         connection.FileWriteFailed += (s, e) =>
         {
             // TODO _fileWriteError = true;

--- a/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeDisableCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeDisableCommand.cs
@@ -9,7 +9,6 @@ public class RuntimeDisableCommand : BaseDeviceCommand<RuntimeEnableCommand>
     public RuntimeDisableCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)
     {
-        Logger?.LogInformation($"Disabling runtime...");
     }
 
     protected override async ValueTask ExecuteCommand()
@@ -20,6 +19,8 @@ public class RuntimeDisableCommand : BaseDeviceCommand<RuntimeEnableCommand>
         {
             if (Connection.Device != null)
             {
+                Logger?.LogInformation($"Disabling runtime...");
+
                 await Connection.Device.RuntimeDisable(CancellationToken);
 
                 var state = await Connection.Device.IsRuntimeEnabled(CancellationToken);

--- a/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeDisableCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeDisableCommand.cs
@@ -19,13 +19,16 @@ public class RuntimeDisableCommand : BaseDeviceCommand<RuntimeEnableCommand>
         {
             if (Connection.Device != null)
             {
-                Logger?.LogInformation($"Disabling runtime...");
+                try
+                {
+                    Logger?.LogInformation($"Disabling runtime...");
 
-                await Connection.Device.RuntimeDisable(CancellationToken);
-
-                var state = await Connection.Device.IsRuntimeEnabled(CancellationToken);
-
-                Logger?.LogInformation($"Runtime is {(state ? "ENABLED" : "DISABLED")}");
+                    await Connection.Device.RuntimeDisable(CancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger?.LogError(ex, $"Failed to disable runtime.");
+                }
             }
         }
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeEnableCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeEnableCommand.cs
@@ -9,7 +9,6 @@ public class RuntimeEnableCommand : BaseDeviceCommand<RuntimeEnableCommand>
     public RuntimeEnableCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)
     {
-        Logger?.LogInformation($"Enabling runtime...");
     }
 
     protected override async ValueTask ExecuteCommand()
@@ -20,6 +19,8 @@ public class RuntimeEnableCommand : BaseDeviceCommand<RuntimeEnableCommand>
         {
             if (Connection.Device != null)
             {
+                Logger?.LogInformation($"Enabling runtime...");
+
                 await Connection.Device.RuntimeEnable(CancellationToken);
 
                 var state = await Connection.Device.IsRuntimeEnabled(CancellationToken);

--- a/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeEnableCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeEnableCommand.cs
@@ -19,13 +19,16 @@ public class RuntimeEnableCommand : BaseDeviceCommand<RuntimeEnableCommand>
         {
             if (Connection.Device != null)
             {
-                Logger?.LogInformation($"Enabling runtime...");
+                try
+                {
+                    Logger?.LogInformation($"Enabling runtime...");
 
-                await Connection.Device.RuntimeEnable(CancellationToken);
-
-                var state = await Connection.Device.IsRuntimeEnabled(CancellationToken);
-
-                Logger?.LogInformation($"Runtime is {(state ? "ENABLED" : "DISABLED")}");
+                    await Connection.Device.RuntimeEnable(CancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger?.LogError(ex, $"Failed to enable runtime.");
+                }
             }
         }
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeStateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeStateCommand.cs
@@ -19,11 +19,16 @@ public class RuntimeStateCommand : BaseDeviceCommand<RuntimeStateCommand>
         {
             if (Connection.Device != null)
             {
-                Logger?.LogInformation($"Querying runtime state...");
+                try
+                {
+                    Logger?.LogInformation($"Querying runtime state...");
 
-                var state = await Connection.Device.IsRuntimeEnabled(CancellationToken);
-
-                Logger?.LogInformation($"Runtime is {(state ? "ENABLED" : "DISABLED")}");
+                    await Connection.Device.IsRuntimeEnabled(CancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    Logger?.LogError(ex, $"Unable to determine the runtime state.");
+                }
             }
         }
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeStateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Runtime/RuntimeStateCommand.cs
@@ -9,7 +9,6 @@ public class RuntimeStateCommand : BaseDeviceCommand<RuntimeStateCommand>
     public RuntimeStateCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)
     {
-        Logger?.LogInformation($"Querying runtime state...");
     }
 
     protected override async ValueTask ExecuteCommand()
@@ -20,6 +19,8 @@ public class RuntimeStateCommand : BaseDeviceCommand<RuntimeStateCommand>
         {
             if (Connection.Device != null)
             {
+                Logger?.LogInformation($"Querying runtime state...");
+
                 var state = await Connection.Device.IsRuntimeEnabled(CancellationToken);
 
                 Logger?.LogInformation($"Runtime is {(state ? "ENABLED" : "DISABLED")}");

--- a/Source/v2/Meadow.Cli/Commands/Legacy/FlashOsCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Legacy/FlashOsCommand.cs
@@ -240,19 +240,6 @@ public class FlashOsCommand : BaseDeviceCommand<FlashOsCommand>
     {
         if (Connection != null)
         {
-            // the connection passes messages back to us (info about actions happening on-device
-            /* TODO Don't think this is needed as it's in the base class now Connection.DeviceMessageReceived += (s, e) =>
-            {
-                if (e.message.Contains("% downloaded"))
-                {
-                    // don't echo this, as we're already reporting % written
-                }
-                else
-                {
-                    Logger?.LogInformation(e.message);
-                }
-            };*/
-
             var package = await GetSelectedPackage();
 
             if (Connection.Device != null

--- a/Source/v2/Meadow.Cli/Program.cs
+++ b/Source/v2/Meadow.Cli/Program.cs
@@ -15,14 +15,9 @@ public class Program
     public static async Task<int> Main(string[] args)
     {
         var logLevel = LogEventLevel.Information;
-        var logModifier = args.FirstOrDefault(a => a.Contains("-m"))
-                              ?.Count(x => x == 'm') ?? 0;
 
-        logLevel -= logModifier;
-        if (logLevel < 0)
-        {
-            logLevel = 0;
-        }
+        if (args.Contains("--verbose"))
+            logLevel = LogEventLevel.Verbose;
 
         var outputTemplate = logLevel == LogEventLevel.Verbose
                                  ? "[{Timestamp:HH:mm:ss.fff} {Level:u3}] {Message:lj}{NewLine}{Exception}"

--- a/Source/v2/Meadow.Hcom/Connections/SerialConnection.ListenerProc.cs
+++ b/Source/v2/Meadow.Hcom/Connections/SerialConnection.ListenerProc.cs
@@ -30,17 +30,7 @@ namespace Meadow.Hcom
 
                 await Task.Delay(500);
 
-                if (!_port.IsOpen)
-                {
-                    try
-                    {
-                        Open();
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine($"Unable to open port: {ex.Message}");
-                    }
-                }
+                Open();
             }
 
             throw new TimeoutException();
@@ -204,7 +194,7 @@ namespace Meadow.Hcom
                                     }
                                     else if (response is ReconnectRequiredResponse rrr)
                                     {
-                                        // the device is going to restart - we need to wait for a HCOM_HOST_REQUEST_TEXT_CONCLUDED to know it's back
+                                        // the device is going to restart - we need to wait for a HCOM_HOST_REQUEST_TEXT_CONCLUDED/TextConcludedResponse to know it's back
                                         State = ConnectionState.Disconnected;
                                         _reconnectInProgress = true;
                                     }


### PR DESCRIPTION
Even though this PR was to *only* fix the runtime command on macOS, in the end I found other issue that needed addressing. Fixes are:
- [x] Runtime commands now no longer timeout, as we listen out for the correct response message.
- [x] - Add `--verbose` option for logging.
- [x] - Some refactoring to add more exception handling and belt and braces defensive coding.
- [x] - Fix a duplicate messages bug introduced in the previous big PR via DeviceMessageReceived.
