### PR TITLE
[v2] Add support for flashing multiple devices...

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,8 +1,8 @@
 name: Meadow.CLI
 env:
-  CLI_RELEASE_VERSION: 1.3.5.0
-  IDE_TOOLS_RELEASE_VERSION: 1.3.5
-  MEADOW_OS_VERSION: 1.3.4.0
+  CLI_RELEASE_VERSION: 1.4.0.0
+  IDE_TOOLS_RELEASE_VERSION: 1.4.0
+  MEADOW_OS_VERSION: 1.4.0.3
   VS_MAC_2019_VERSION: 8.10
   VS_MAC_2022_VERSION: 17.5
 
@@ -107,6 +107,11 @@ jobs:
         name: Meadow.CLI.nuget.${{ ENV.CLI_RELEASE_VERSION }}
         path: 'main\Meadow.CLI\bin\Release\*.nupkg'
 
+    - if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+      name: Publish Meadow.CLI Nuget publically
+      run: |
+        nuget push main\Meadow.CLI\bin\Release\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+
     - name: Restore V2 dependencies
       run: dotnet restore main/Source/v2/Meadow.CLI.v2.sln /p:Configuration=Release
 
@@ -116,13 +121,13 @@ jobs:
     - name: Upload nuget Artifacts for internal testing
       uses: actions/upload-artifact@v2
       with:
-        name: Meadow.CLI.V2.nuget.${{ ENV.CLI_RELEASE_VERSION }}
+        name: Meadow.CLI.V2.nuget.2.0.0
         path: 'main\Source\v2\Meadow.Cli\bin\Release\*.nupkg'
 
     - if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
-      name: Publish Meadow.CLI Nuget publically
+      name: Publish Meadow.CLI v2.0 Nuget publically
       run: |
-        nuget push main\Meadow.CLI\bin\Release\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+        nuget push main\Source\v2\Meadow.Cli\bin\Release\*.nupkg -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
 
   build-vswin-2019:
     runs-on: windows-2019

--- a/Meadow.CLI.Core/Constants.cs
+++ b/Meadow.CLI.Core/Constants.cs
@@ -7,7 +7,7 @@ namespace Meadow.CLI.Core
 {
     public static class Constants
     {
-        public const string CLI_VERSION = "1.3.5.0";
+        public const string CLI_VERSION = "1.4.0.0";
         public const ushort HCOM_PROTOCOL_PREVIOUS_VERSION_NUMBER = 0x0006;
         public const ushort HCOM_PROTOCOL_CURRENT_VERSION_NUMBER = 0x0007;         // Used for transmission
         public const string WILDERNESS_LABS_USB_VID = "2E6A";

--- a/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.6.0.0.csproj
@@ -11,7 +11,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.3.5.0</Version>
+    <Version>1.4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Meadow.CLI.Core/Meadow.CLI.Core.Classic.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.Classic.csproj
@@ -11,7 +11,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.3.5.0</Version>
+    <Version>1.4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.VS2019.csproj
@@ -11,7 +11,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.3.5.0</Version>
+    <Version>1.4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Meadow.CLI.Core/Meadow.CLI.Core.csproj
+++ b/Meadow.CLI.Core/Meadow.CLI.Core.csproj
@@ -11,7 +11,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.3.5.0</Version>
+    <Version>1.4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Meadow.CLI/Meadow.CLI.Classic.csproj
+++ b/Meadow.CLI/Meadow.CLI.Classic.csproj
@@ -10,7 +10,7 @@
     <Authors>Peter Moody, Adrian Stevens, Brian Kim, Pete Garafano, Dominique Louis</Authors>
     <Company>Wilderness Labs, Inc</Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>1.3.5.0</PackageVersion>
+    <PackageVersion>1.4.0.0</PackageVersion>
     <Platforms>AnyCPU</Platforms>
     <PackageProjectUrl>http://developer.wildernesslabs.co/Meadow/Meadow.Foundation/</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>

--- a/Meadow.CLI/Meadow.CLI.csproj
+++ b/Meadow.CLI/Meadow.CLI.csproj
@@ -10,7 +10,7 @@
     <Authors>Peter Moody, Adrian Stevens, Brian Kim, Pete Garafano, Dominique Louis</Authors>
     <Company>Wilderness Labs, Inc</Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>1.3.5.0</PackageVersion>
+    <PackageVersion>1.4.0.0</PackageVersion>
     <Platforms>AnyCPU</Platforms>
     <PackageProjectUrl>http://developer.wildernesslabs.co/Meadow/Meadow.Foundation/</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>

--- a/Source/v2/Meadow.CLI/Meadow.CLI.csproj
+++ b/Source/v2/Meadow.CLI/Meadow.CLI.csproj
@@ -8,10 +8,10 @@
 	  <Company>Wilderness Labs, Inc</Company>
 	  <ToolCommandName>meadow</ToolCommandName>
 	  <PackageId>WildernessLabs.Meadow.CLI</PackageId>
-	  <Authors>Wilderness Labs, Inc</Authors>
+	  <Authors>Chris Tacke, Peter Moody, Adrian Stevens, Brian Kim, Pete Garafano, Dominique Louis</Authors>
 	  <Company>Wilderness Labs, Inc</Company>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <PackageVersion>2.0.0.0-alpha</PackageVersion>
+	  <PackageVersion>2.0.0-alpha.1</PackageVersion>
 	  <Platforms>AnyCPU</Platforms>
 	  <PackageProjectUrl>http://developer.wildernesslabs.co/Meadow/Meadow.Foundation/</PackageProjectUrl>
 	  <PackageIcon>icon.png</PackageIcon>
@@ -24,8 +24,10 @@
 	  <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
 	  <AssemblyName>meadow</AssemblyName>
 	  <LangVersion>latest</LangVersion>
-	  <Copyright>Copyright 2020-2022 Wilderness Labs</Copyright>
+	  <Copyright>Copyright 2020-2023 Wilderness Labs</Copyright>
 	  <Nullable>enable</Nullable>
+	  <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+	  <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -79,4 +81,7 @@
 	  </None>
 	</ItemGroup>
 
+	<ItemGroup>
+	    <None Include="..\..\..\README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 </Project>

--- a/Source/v2/Meadow.CLI/Meadow.CLI.csproj
+++ b/Source/v2/Meadow.CLI/Meadow.CLI.csproj
@@ -82,6 +82,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	    <None Include="..\..\..\README.md" Pack="true" PackagePath="\"/>
+	    <None Include="..\..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/Source/v2/Meadow.CLI/Meadow.CLI.csproj
+++ b/Source/v2/Meadow.CLI/Meadow.CLI.csproj
@@ -51,12 +51,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\Meadow.Cli.Core\Meadow.Cli.Core.csproj" />
 	  <ProjectReference Include="..\Meadow.Cloud.Client\Meadow.Cloud.Client.csproj" />
-	  <ProjectReference Include="..\Meadow.Hcom\Meadow.Hcom.csproj" />
 	  <ProjectReference Include="..\Meadow.SoftwareManager\Meadow.SoftwareManager.csproj" />
 	  <ProjectReference Include="..\Meadow.UsbLibClassic\Meadow.UsbLibClassic.csproj" />
 	  <ProjectReference Include="..\Meadow.UsbLib\Meadow.UsbLib.csproj" />
+	  <ProjectReference Include="..\Meadow.CLI.Core\Meadow.CLI.Core.csproj" />
+	  <ProjectReference Include="..\Meadow.HCom\Meadow.HCom.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
@@ -13,7 +13,7 @@ public abstract class BaseCommand<T> : ICommand
     protected IConsole? Console { get; private set; }
     protected CancellationToken CancellationToken { get; private set; }
 
-    [CommandOption("verbose", 'v', IsRequired = false)]
+    [CommandOption("verbose", IsRequired = false)]
     public bool Verbose { get; set; }
 
     public BaseCommand(ILoggerFactory? loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCommand.cs
@@ -1,6 +1,8 @@
 ﻿using CliFx;
+using CliFx.Attributes;
 using CliFx.Infrastructure;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
@@ -10,6 +12,9 @@ public abstract class BaseCommand<T> : ICommand
     protected ILoggerFactory? LoggerFactory { get; }
     protected IConsole? Console { get; private set; }
     protected CancellationToken CancellationToken { get; private set; }
+
+    [CommandOption("verbose", 'v', IsRequired = false)]
+    public bool Verbose { get; set; }
 
     public BaseCommand(ILoggerFactory? loggerFactory)
     {

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
@@ -79,6 +79,10 @@ public abstract class BaseDeviceCommand<T> : BaseCommand<T>
         {
             // don't echo this, as we're already reporting % written
         }
+        else if(e.source != null && e.source.Contains("stdout"))
+        {
+            // don't echo this, as we're already reporting it higher up
+        }
         else
         {
             Logger?.LogInformation(e.message);

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseDeviceCommand.cs
@@ -24,28 +24,7 @@ public abstract class BaseDeviceCommand<T> : BaseCommand<T>
 
         if (connection != null)
         {
-            connection.ConnectionError += (s, e) =>
-            {
-                Logger?.LogError(e.Message);
-            };
-
-            connection.ConnectionMessage += (s, message) =>
-            {
-                Logger?.LogInformation(message);
-            };
-
-            // the connection passes messages back to us (info about actions happening on-device)
-            connection.DeviceMessageReceived += (s, e) =>
-            {
-                if (e.message.Contains("% downloaded"))
-                {
-                    // don't echo this, as we're already reporting % written
-                }
-                else
-                {
-                    Logger?.LogInformation(e.message);
-                }
-            };
+            AttachMessageHandlers(connection);
 
             try
             {
@@ -79,5 +58,53 @@ public abstract class BaseDeviceCommand<T> : BaseCommand<T>
         }
 
         return null;
+    }
+
+    private void AttachMessageHandlers(IMeadowConnection? connection)
+    {
+        if (connection != null)
+        {
+            connection.ConnectionError += Connection_ConnectionError;
+
+            connection.ConnectionMessage += Connection_ConnectionMessage;
+
+            // the connection passes messages back to us (info about actions happening on-device)
+            connection.DeviceMessageReceived += Connection_DeviceMessageReceived;
+        }
+    }
+
+    private void Connection_DeviceMessageReceived(object? sender, (string message, string? source) e)
+    {
+        if (e.message.Contains("% downloaded"))
+        {
+            // don't echo this, as we're already reporting % written
+        }
+        else
+        {
+            Logger?.LogInformation(e.message);
+        }
+    }
+
+    private void Connection_ConnectionMessage(object? sender, string message)
+    {
+        Logger?.LogInformation(message);
+    }
+
+    private void Connection_ConnectionError(object? sender, Exception e)
+    {
+        Logger?.LogError(e.Message);
+    }
+
+    public void DetachMessageHandlers(IMeadowConnection? connection)
+    {
+        if (connection != null)
+        {
+            connection.ConnectionError -= Connection_ConnectionError;
+
+            connection.ConnectionMessage -= Connection_ConnectionMessage;
+
+            // the connection passes messages back to us (info about actions happening on-device)
+            connection.DeviceMessageReceived -= Connection_DeviceMessageReceived;
+        }
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/File/FileListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/File/FileListCommand.cs
@@ -8,9 +8,6 @@ public class FileListCommand : BaseDeviceCommand<FileListCommand>
 {
     public const int FileSystemBlockSize = 4096;
 
-    [CommandOption("verbose", 'v', IsRequired = false)]
-    public bool Verbose { get; set; }
-
     public FileListCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)
     {

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareListCommand.cs
@@ -10,9 +10,6 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 [Command("firmware list", Description = "List locally available firmware")]
 public class FirmwareListCommand : BaseCommand<FirmwareListCommand>
 {
-    [CommandOption("verbose", 'v', IsRequired = false)]
-    public bool Verbose { get; set; }
-
     private FileManager FileManager { get; }
 
     public FirmwareListCommand(FileManager fileManager, ILoggerFactory? loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareWriteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareWriteCommand.cs
@@ -75,7 +75,7 @@ public class FirmwareWriteCommand : BaseDeviceCommand<FirmwareWriteCommand>
 
         IMeadowConnection? connection;
 
-        if (UseDfu && Files != null && Files.Contains(FirmwareType.OS) && package != null)
+        if (UseDfu && Files != null && package != null)
         {
             // get the device's serial number via DFU - we'll need it to find the device after it resets
             try
@@ -113,7 +113,7 @@ public class FirmwareWriteCommand : BaseDeviceCommand<FirmwareWriteCommand>
 
                     try
                     {
-                        if (package != null && package.OSWithBootloader != null)
+                        if (package != null && package.OSWithBootloader != null && Files.Contains(FirmwareType.OS))
                         {
                             await WriteOsWithDfu(package.GetFullyQualifiedPath(package.OSWithBootloader), serialNumber);
                         }
@@ -158,7 +158,7 @@ public class FirmwareWriteCommand : BaseDeviceCommand<FirmwareWriteCommand>
                                     continue;
                                 }
 
-                                await WriteFiles(connection);
+                                await WriteFiles(package, connection);
                             }
                         }
                         catch (Exception ex)
@@ -240,14 +240,13 @@ public class FirmwareWriteCommand : BaseDeviceCommand<FirmwareWriteCommand>
         return package;
     }
 
-    private async ValueTask WriteFiles(IMeadowConnection connection)
+    private async ValueTask WriteFiles(FirmwarePackage? package, IMeadowConnection connection)
     {
         connection.FileWriteFailed += (s, e) =>
         {
+            Logger?.LogError($"WriteFiles FAILED!!");
             // TODO _fileWriteError = true;
         };
-
-        var package = await GetSelectedPackage();
 
         if (Files != null
             && connection.Device != null

--- a/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
@@ -20,28 +20,30 @@ public class ListenCommand : BaseDeviceCommand<ListenCommand>
 
     private void OnDeviceMessageReceived(object? sender, (string message, string? source) e)
     {
+        string textColour;
+        switch (e.source)
+        {
+            case "stdout":
+                textColour = StringExtensions.ConsoleColourBlue;
+                break;
+            case "info":
+                textColour = StringExtensions.ConsoleColourGreen;
+                break;
+            case "stderr":
+                textColour = StringExtensions.ConsoleColourRed;
+                break;
+            default:
+                textColour = StringExtensions.ConsoleColourReset;
+                break;
+        }
+
         if (NoPrefix)
         {
-            Logger?.LogInformation($"{e.message.TrimEnd('\n', '\r')}");
+            Logger?.LogInformation($"{e.message.TrimEnd('\n', '\r').ColourConsoleText(textColour)}");
         }
         else
         {
-            string textColour; 
-            switch (e.source)
-            {
-                case "stdout":
-                    textColour = StringExtensions.ConsoleColourBlue;
-                    break;
-                case "info":
-                    textColour = StringExtensions.ConsoleColourGreen;
-                    break;
-                case "stderr":
-                    textColour = StringExtensions.ConsoleColourRed;
-                    break;
-                default:
-                    textColour = StringExtensions.ConsoleColourReset;
-                    break;
-            }
+
             Logger?.LogInformation($"{e.source?.ColourConsoleText(textColour)}> {e.message.TrimEnd('\n', '\r')}");
         }
     }

--- a/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
@@ -26,7 +26,7 @@ public class ListenCommand : BaseDeviceCommand<ListenCommand>
         }
         else
         {
-            Logger?.LogInformation($"{e.source}> {e.message.TrimEnd('\n', '\r')}");
+            Logger?.LogInformation($"{Constants.ColourConsoleText(Constants.ConsoleColourBlue, e.source!)}> {e.message.TrimEnd('\n', '\r')}");
         }
     }
 

--- a/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
@@ -26,7 +26,23 @@ public class ListenCommand : BaseDeviceCommand<ListenCommand>
         }
         else
         {
-            Logger?.LogInformation($"{Constants.ColourConsoleText(Constants.ConsoleColourBlue, e.source!)}> {e.message.TrimEnd('\n', '\r')}");
+            string textColour; 
+            switch (e.source)
+            {
+                case "stdout":
+                    textColour = StringExtensions.ConsoleColourBlue;
+                    break;
+                case "info":
+                    textColour = StringExtensions.ConsoleColourGreen;
+                    break;
+                case "stderr":
+                    textColour = StringExtensions.ConsoleColourRed;
+                    break;
+                default:
+                    textColour = StringExtensions.ConsoleColourReset;
+                    break;
+            }
+            Logger?.LogInformation($"{e.source?.ColourConsoleText(textColour)}> {e.message.TrimEnd('\n', '\r')}");
         }
     }
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Port/PortListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Port/PortListCommand.cs
@@ -6,7 +6,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 [Command("port list", Description = "List available local serial ports")]
 public class PortListCommand : BaseCommand<PortListCommand>
 {
-    public IList<string>? Portlist;
+    public IList<MeadowSerialPort>? Portlist;
 
     public PortListCommand(ILoggerFactory loggerFactory)
         : base(loggerFactory)
@@ -22,7 +22,7 @@ public class PortListCommand : BaseCommand<PortListCommand>
             Logger?.LogInformation($"Found the following device{plural}:");
             for (int i = 0; i < Portlist.Count; i++)
             {
-                Logger?.LogInformation($" {i + 1}: {Portlist[i]}");
+                Logger?.LogInformation($" {i + 1}: {Portlist[i].Name}");
             }
         }
         else

--- a/Source/v2/Meadow.Cli/Commands/Current/Port/PortSelectCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Port/PortSelectCommand.cs
@@ -33,7 +33,7 @@ public class PortSelectCommand : BaseCommand<PortSelectCommand>
                         {
                             if (deviceSelected > 0 && deviceSelected <= portListCommand.Portlist?.Count)
                             {
-                                await CallConfigCommand(portListCommand.Portlist[deviceSelected - 1]);
+                                await CallConfigCommand(portListCommand.Portlist[deviceSelected - 1].Name!);
                             }
                         }
                     }
@@ -41,7 +41,7 @@ public class PortSelectCommand : BaseCommand<PortSelectCommand>
                     {
                         // Only 1 device attached, let's auto select it
                         if (portListCommand.Portlist != null)
-                            await CallConfigCommand(portListCommand.Portlist[0]);
+                            await CallConfigCommand(portListCommand.Portlist[0].Name!);
                     }
                 }
             }

--- a/Source/v2/Meadow.Cli/Commands/Legacy/FlashOsCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Legacy/FlashOsCommand.cs
@@ -148,25 +148,28 @@ public class FlashOsCommand : BaseDeviceCommand<FlashOsCommand>
                     }
 
                     // configure the route to that port for the user
-                    Settings.SaveSetting(SettingsManager.PublicSettings.Route, newPort);
-
-                    var cancellationToken = Console?.RegisterCancellationHandler();
-
-                    if (Files.Any(f => f != FirmwareType.OS))
+                    if (newPort != null)
                     {
-                        await Connection.WaitForMeadowAttach();
+                        Settings.SaveSetting(SettingsManager.PublicSettings.Route, newPort.Name!);
 
-                        await WriteFiles();
-                    }
+                        var cancellationToken = Console?.RegisterCancellationHandler();
 
-                    if (Connection.Device != null)
-                    {
-                        var deviceInfo = await Connection.Device.GetDeviceInfo(cancellationToken);
-
-                        if (deviceInfo != null)
+                        if (Files.Any(f => f != FirmwareType.OS))
                         {
-                            Logger?.LogInformation($"Done.");
-                            Logger?.LogInformation(deviceInfo.ToString());
+                            await Connection.WaitForMeadowAttach();
+
+                            await WriteFiles();
+                        }
+
+                        if (Connection.Device != null)
+                        {
+                            var deviceInfo = await Connection.Device.GetDeviceInfo(cancellationToken);
+
+                            if (deviceInfo != null)
+                            {
+                                Logger?.LogInformation($"Done.");
+                                Logger?.LogInformation(deviceInfo.ToString());
+                            }
                         }
                     }
                 }

--- a/Source/v2/Meadow.Cli/MeadowConnectionManager.cs
+++ b/Source/v2/Meadow.Cli/MeadowConnectionManager.cs
@@ -1,7 +1,9 @@
 ﻿using Meadow.Cli;
 using Meadow.Hcom;
+using Meadow.LibUsb;
 using System.Diagnostics;
 using System.IO.Ports;
+using System.Linq;
 using System.Management;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -293,5 +295,33 @@ public class MeadowConnectionManager
 
             return ports;
         }
+    }
+
+    public static async Task<string> GetPortFromSerialNumber(string serialNumber)
+    {
+
+        var retryCount = 0;
+
+        string? newPort = null;
+
+        // now wait for the serial port with the passed in serialNumber to appear
+        while (newPort == null)
+        {
+            var ports = await GetSerialPorts();
+            newPort = ports.Where(s => s.Contains(serialNumber)).FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(newPort))
+            {
+                break;
+            }
+
+            if (retryCount++ > 12)
+            {
+                throw new Exception("New meadow device not found");
+            }
+            await Task.Delay(500);
+        }
+
+        return newPort;
     }
 }

--- a/Source/v2/Meadow.Cli/MeadowConnectionManager.cs
+++ b/Source/v2/Meadow.Cli/MeadowConnectionManager.cs
@@ -213,7 +213,7 @@ public class MeadowConnectionManager
                                   var parts = line.Split(new[] { "-> " }, StringSplitOptions.RemoveEmptyEntries);
                                   var target = parts[1];
                                   var port = Path.GetFullPath(Path.Combine(devicePath, target));
-                                  int serialNumberIndex = line.IndexOf("ttyUSB") + 6;
+                                  int serialNumberIndex = line.IndexOf("ttyACM") + 6;
                                   var serialNumber = line.Substring(serialNumberIndex);
 
                                   return new MeadowSerialPort { Name = port, SerialNumber = serialNumber };

--- a/Source/v2/Meadow.Cli/Properties/AssemblyInfo.cs
+++ b/Source/v2/Meadow.Cli/Properties/AssemblyInfo.cs
@@ -7,30 +7,29 @@ namespace Meadow.CLI
     public static class Constants
     {
         public const string CLI_VERSION = "2.0.0.0";
+    }
 
-        public const string ConsoleColourRed = "\u001b[31m";
-        public const string ConsoleColourGreen = "\u001b[32m";
-        public const string ConsoleColourYellow = "\u001b[33m";
+    public static class StringExtensions
+    {
+        public const string ConsoleColourBlack = "\u001b[30m";
         public const string ConsoleColourBlue = "\u001b[34m";
-        public const string ConsoleColourClear = "\u001b[0m";
+        public const string ConsoleColourCyan = "\u001b[36m";
+        public const string ConsoleColourGreen = "\u001b[32m";
+        public const string ConsoleColourMagenta = "\u001b[35m";
+        public const string ConsoleColourRed = "\u001b[31m";
+        public const string ConsoleColourReset = "\u001b[0m";
+        public const string ConsoleColourWhite = "\u001b[37m";
+        public const string ConsoleColourYellow = "\u001b[33m";
 
-        public static string ColourConsoleText(string? textColour, string? textToColour)
+        public static string ColourConsoleText(this string textToColour, string textColour)
         {
-            if (!string.IsNullOrEmpty(textColour)
-                && !string.IsNullOrEmpty(textToColour))
+            if (!string.IsNullOrEmpty(textToColour))
             {
-                return textColour + textToColour + ConsoleColourClear;
+                return textColour + textToColour + ConsoleColourReset;
             }
             else
             {
-                if (!string.IsNullOrEmpty(textToColour))
-                {
-                    return textToColour;
-                }
-                else
-                {
-                    return string.Empty;
-                }
+                return string.Empty;
             }
         }
     }

--- a/Source/v2/Meadow.Cli/Properties/AssemblyInfo.cs
+++ b/Source/v2/Meadow.Cli/Properties/AssemblyInfo.cs
@@ -7,5 +7,31 @@ namespace Meadow.CLI
     public static class Constants
     {
         public const string CLI_VERSION = "2.0.0.0";
+
+        public const string ConsoleColourRed = "\u001b[31m";
+        public const string ConsoleColourGreen = "\u001b[32m";
+        public const string ConsoleColourYellow = "\u001b[33m";
+        public const string ConsoleColourBlue = "\u001b[34m";
+        public const string ConsoleColourClear = "\u001b[0m";
+
+        public static string ColourConsoleText(string? textColour, string? textToColour)
+        {
+            if (!string.IsNullOrEmpty(textColour)
+                && !string.IsNullOrEmpty(textToColour))
+            {
+                return textColour + textToColour + ConsoleColourClear;
+            }
+            else
+            {
+                if (!string.IsNullOrEmpty(textToColour))
+                {
+                    return textToColour;
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+        }
     }
 }

--- a/Source/v2/Meadow.Hcom/Connections/SerialConnection.cs
+++ b/Source/v2/Meadow.Hcom/Connections/SerialConnection.cs
@@ -1030,7 +1030,8 @@ public partial class SerialConnection : ConnectionBase, IDisposable
         if (!await WaitForResult(
                 () =>
                 {
-                    if (ex != null) throw ex;
+                    if (ex != null)
+                        throw ex;
                     return accepted;
                 },
                 cancellationToken))

--- a/Source/v2/Meadow.UsbLib/Meadow.UsbLib.csproj
+++ b/Source/v2/Meadow.UsbLib/Meadow.UsbLib.csproj
@@ -11,7 +11,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Meadow.Cli.Core\Meadow.Cli.Core.csproj" />
+    <ProjectReference Include="..\Meadow.CLI.Core\Meadow.CLI.Core.csproj" />
   </ItemGroup>
 
     <ItemGroup>

--- a/Source/v2/Meadow.UsbLibClassic/Meadow.UsbLibClassic.csproj
+++ b/Source/v2/Meadow.UsbLibClassic/Meadow.UsbLibClassic.csproj
@@ -11,7 +11,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Meadow.Cli.Core\Meadow.Cli.Core.csproj" />
+    <ProjectReference Include="..\Meadow.CLI.Core\Meadow.CLI.Core.csproj" />
 
   </ItemGroup>
 


### PR DESCRIPTION
Sequentially flashes multiple devices that are in bootloader mode.
- [x] Works on Mac
- [ ] Works on Windows
- [ ] Works on Linux

Status summary:
<img width="400" alt="Screenshot 2023-10-30 at 14 13 42" src="https://github.com/WildernessLabs/Meadow.CLI/assets/271363/3bdf088c-337c-4611-b8dc-4f465a164054">


PR also:
* Adds Licences, Readme and updates the Copyright.
* Fixes a bug where `--verbose` didn't work correct across all commands.
* Remove duplicate messages in `meadow listen` 
* Adds console colour text extension method so, at a glance we can see success and failure (may need further tweaking).