### PR TITLE
Add management of Meadow.Cloud API keys

### DIFF
--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
@@ -1,0 +1,73 @@
+﻿using CliFx.Attributes;
+using CliFx.Exceptions;
+using Meadow.Cloud;
+using Meadow.Cloud.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+[Command("cloud apikey create", Description = "Create a Meadow.Cloud API key")]
+public class CloudApiKeyCreateCommand : BaseCloudCommand<CloudApiKeyCreateCommand>
+{
+    [CommandParameter(0, Description = "The name of the API key", IsRequired = true, Name = "NAME")]
+    public string? Name { get; set; }
+
+    [CommandOption("duration", 'd', Description = "The duration of the API key, in days", IsRequired = true)]
+    public int Duration { get; set; }
+
+    [CommandOption("scopes", 's', Description = "The list of scopes (permissions) to grant the API key", IsRequired = true)]
+    public string[]? Scopes { get; set; }
+
+    [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})")]
+    public string? Host { get; set; }
+
+    private ApiTokenService ApiTokenService { get; }
+
+    public CloudApiKeyCreateCommand(
+        ApiTokenService apiTokenService,
+        CollectionService collectionService,
+        DeviceService deviceService,
+        IdentityManager identityManager,
+        UserService userService,
+        ILoggerFactory? loggerFactory)
+        : base(identityManager, userService, deviceService, collectionService, loggerFactory)
+    {
+        ApiTokenService = apiTokenService;
+    }
+
+    protected async override ValueTask ExecuteCommand()
+    {
+        if (Duration < 1 || Duration > 90)
+        {
+            throw new CommandException("Duration (-d|--duration) must be between 1 and 90 days.", showHelp: true);
+        }
+
+        Host ??= DefaultHost;
+
+        Logger?.LogInformation($"Creating an API key on Meadow.Cloud{(Host != DefaultHost ? $" ({Host.ToLowerInvariant()})" : string.Empty)}...");
+
+        var token = await IdentityManager.GetAccessToken(CancellationToken);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+        }
+
+        try
+        {
+            var request = new CreateApiTokenRequest(Name!, Duration, Scopes!);
+            var response = await ApiTokenService.CreateApiToken(request, Host, CancellationToken);
+
+            Logger?.LogInformation($"Your API key '{response.Name}' (expiring {response.ExpiresAt:G} UTC) is:");
+            Logger?.LogInformation($"\n{response.Token}\n");
+            Logger?.LogInformation("Make sure to copy this key now as you will not be able to see this again.");
+        }
+        catch (MeadowCloudAuthException ex)
+        {
+            throw new CommandException("You must be signed in to execute this command.", innerException: ex);
+        }
+        catch (MeadowCloudException ex)
+        {
+            throw new CommandException($"Create API key command failed: {ex.Message}", innerException: ex);
+        }
+    }
+}

--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
@@ -1,0 +1,65 @@
+﻿using CliFx.Attributes;
+using CliFx.Exceptions;
+using Meadow.Cloud;
+using Meadow.Cloud.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+[Command("cloud apikey delete", Description = "Delete a Meadow.Cloud API key")]
+public class CloudApiKeyDeleteCommand : BaseCloudCommand<CloudApiKeyDeleteCommand>
+{
+    [CommandParameter(0, Description = "The name or ID of the API key", IsRequired = true, Name = "NAME_OR_ID")]
+    public string? NameOrId { get; set; }
+
+    [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]
+    public string? Host { get; set; }
+
+    private ApiTokenService ApiTokenService { get; }
+
+    public CloudApiKeyDeleteCommand(
+        ApiTokenService apiTokenService,
+        CollectionService collectionService,
+        DeviceService deviceService,
+        IdentityManager identityManager,
+        UserService userService,
+        ILoggerFactory? loggerFactory)
+        : base(identityManager, userService, deviceService, collectionService, loggerFactory)
+    {
+        ApiTokenService = apiTokenService;
+    }
+
+    protected async override ValueTask ExecuteCommand()
+    {
+        Host ??= DefaultHost;
+
+        Logger?.LogInformation($"Deleting API key `{NameOrId}` on Meadow.Cloud{(Host != DefaultHost ? $" ({Host.ToLowerInvariant()})" : string.Empty)}...");
+
+        var token = await IdentityManager.GetAccessToken(CancellationToken);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+        }
+
+        try
+        {
+            var getRequest = await ApiTokenService.GetApiTokens(Host, CancellationToken);
+            var apiKey = getRequest.FirstOrDefault(x => x.Id == NameOrId || string.Equals(x.Name, NameOrId, StringComparison.OrdinalIgnoreCase));
+
+            if (apiKey == null)
+            {
+                throw new CommandException($"API key `{NameOrId}` not found.");
+            }
+
+            await ApiTokenService.DeleteApiToken(apiKey.Id, Host, CancellationToken);
+        }
+        catch (MeadowCloudAuthException ex)
+        {
+            throw new CommandException("You must be signed in to execute this command.", innerException: ex);
+        }
+        catch (MeadowCloudException ex)
+        {
+            throw new CommandException($"Create API key command failed: {ex.Message}", innerException: ex);
+        }
+    }
+}

--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
@@ -1,0 +1,71 @@
+﻿using CliFx.Attributes;
+using CliFx.Exceptions;
+using Meadow.Cloud;
+using Meadow.Cloud.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+[Command("cloud apikey list", Description = "List your Meadow.Cloud API keys")]
+public class CloudApiKeyListCommand : BaseCloudCommand<CloudApiKeyListCommand>
+{
+    [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]
+    public string? Host { get; set; }
+
+    private ApiTokenService ApiTokenService { get; }
+
+    public CloudApiKeyListCommand(
+        ApiTokenService apiTokenService,
+        CollectionService collectionService,
+        DeviceService deviceService,
+        IdentityManager identityManager,
+        UserService userService,
+        ILoggerFactory? loggerFactory)
+        : base(identityManager, userService, deviceService, collectionService, loggerFactory)
+    {
+        ApiTokenService = apiTokenService;
+    }
+
+    protected override async ValueTask ExecuteCommand()
+    {
+        Host ??= DefaultHost;
+
+        Logger?.LogInformation($"Retrieving your API keys from Meadow.Cloud{(Host != DefaultHost ? $" ({Host.ToLowerInvariant()})" : string.Empty)}...");
+
+        var token = await IdentityManager.GetAccessToken(CancellationToken);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+        }
+
+        try
+        {
+            var response = await ApiTokenService.GetApiTokens(Host, CancellationToken);
+            var apiTokens = response.OrderBy(a => a.Name);
+
+            if (!apiTokens.Any())
+            {
+                Logger?.LogInformation("You have no API keys.");
+                return;
+            }
+
+            var table = new ConsoleTable("Id", "Name", $"Expires (UTC)", "Scopes");
+            foreach (var apiToken in apiTokens)
+            {
+                table.AddRow(apiToken.Id, apiToken.Name, $"{apiToken.ExpiresAt:G}", string.Join(", ", apiToken.Scopes.OrderBy(t => t)));
+            }
+
+            Logger?.LogInformation(table);
+        }
+        catch (MeadowCloudAuthException ex)
+        {
+            throw new CommandException("You must be signed in to execute this command.", innerException: ex);
+        }
+        catch (MeadowCloudException ex)
+        {
+            throw new CommandException($"Get API keys command failed: {ex.Message}", innerException: ex);
+        }
+    }
+}
+
+

--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
@@ -1,0 +1,75 @@
+﻿using CliFx.Attributes;
+using CliFx.Exceptions;
+using Meadow.Cloud;
+using Meadow.Cloud.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+[Command("cloud apikey update", Description = "Update a Meadow.Cloud API key")]
+public class CloudApiKeyUpdateCommand : BaseCloudCommand<CloudApiKeyUpdateCommand>
+{
+    [CommandParameter(0, Description = "The name or ID of the API key", IsRequired = true, Name = "NAME_OR_ID")]
+    public string? NameOrId { get; set; }
+
+    [CommandOption("name", 'n', Description = "The new name to use for the API key")]
+    public string? NewName { get; set; }
+
+    [CommandOption("scopes", 's', Description = "The list of scopes (permissions) to grant the API key")]
+    public string[]? Scopes { get; set; }
+
+    [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]
+    public string? Host { get; set; }
+
+    private ApiTokenService ApiTokenService { get; }
+
+    public CloudApiKeyUpdateCommand(
+        ApiTokenService apiTokenService,
+        CollectionService collectionService,
+        DeviceService deviceService,
+        IdentityManager identityManager,
+        UserService userService,
+        ILoggerFactory? loggerFactory)
+        : base(identityManager, userService, deviceService, collectionService, loggerFactory)
+    {
+        ApiTokenService = apiTokenService;
+    }
+
+    protected async override ValueTask ExecuteCommand()
+    {
+        Host ??= DefaultHost;
+
+        Logger?.LogInformation($"Updating API key `{NameOrId}` on Meadow.Cloud{(Host != DefaultHost ? $" ({Host.ToLowerInvariant()})" : string.Empty)}...");
+
+        var token = await IdentityManager.GetAccessToken(CancellationToken);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+        }
+
+        try
+        {
+            var getRequest = await ApiTokenService.GetApiTokens(Host, CancellationToken);
+            var apiKey = getRequest.FirstOrDefault(x => x.Id == NameOrId || string.Equals(x.Name, NameOrId, StringComparison.OrdinalIgnoreCase));
+
+            if (apiKey == null)
+            {
+                throw new CommandException($"API key `{NameOrId}` not found.");
+            }
+
+            NewName ??= apiKey.Name;
+            Scopes ??= apiKey.Scopes;
+
+            var updateRequest = new UpdateApiTokenRequest(NewName!, Scopes!);
+            await ApiTokenService.UpdateApiToken(apiKey.Id, updateRequest, Host, CancellationToken);
+        }
+        catch (MeadowCloudAuthException ex)
+        {
+            throw new CommandException("You must be signed in to execute this command.", innerException: ex);
+        }
+        catch (MeadowCloudException ex)
+        {
+            throw new CommandException($"Create API key command failed: {ex.Message}", innerException: ex);
+        }
+    }
+}

--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ConsoleTable.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ConsoleTable.cs
@@ -1,0 +1,107 @@
+﻿using System.Text;
+
+namespace Meadow.CLI;
+
+public class ConsoleTable
+{
+    private readonly string[] _columns;
+    private IList<string[]> _rows;
+
+    public ConsoleTable(params string[] columns)
+    {
+        _columns = columns;
+        _rows = new List<string[]>();
+    }
+
+    public void AddRow(params object[] values)
+    {
+        if (values.Length != _columns.Length)
+        {
+            throw new InvalidOperationException("The number of values for the given row does not match the number of columns.");
+        }
+
+        _rows.Add(values.Select(v => Convert.ToString(v) ?? string.Empty).ToArray());
+    }
+
+    public static implicit operator string(ConsoleTable table) => table.Render();
+
+    public string Render()
+    {
+        var maxWidths = new int[_columns.Length];
+        for (var i = 0; i < _columns.Length; i++)
+        {
+            maxWidths[i] = _columns[i].Length;
+        }
+
+        for (var i = 0; i < _rows.Count; i++)
+        {
+            for (var j = 0; j < _rows[i].Length; j++)
+            {
+                maxWidths[j] = Math.Max(maxWidths[j], _rows[i][j].Length);
+            }
+        }
+
+        var sb = new StringBuilder();
+
+        // Divider
+        sb.AppendLine();
+        for (var i = 0; i < _columns.Length; i++)
+        {
+            sb.Append(new string('-', maxWidths[i]));
+            if (i < _columns.Length - 1)
+            {
+                sb.Append("-+-");
+            }
+        }
+
+        // Header
+        sb.AppendLine();
+        for (var i = 0; i < _columns.Length; i++)
+        {
+            sb.Append(_columns[i].PadRight(maxWidths[i]));
+            if (i < _columns.Length - 1)
+            {
+                sb.Append(" | ");
+            }
+        }
+
+        // Divider
+        sb.AppendLine();
+        for (var i = 0; i < _columns.Length; i++)
+        {
+            sb.Append(new string('-', maxWidths[i]));
+            if (i < _columns.Length - 1)
+            {
+                sb.Append("-|-");
+            }
+        }
+
+        // Rows
+        for (var i = 0; i < _rows.Count; i++)
+        {
+            sb.AppendLine();
+            for (var j = 0; j < _rows[i].Length; j++)
+            {
+                sb.Append(_rows[i][j].PadRight(maxWidths[j]));
+                if (j < _rows[i].Length - 1)
+                {
+                    sb.Append(" | ");
+                }
+            }
+        }
+
+        // Divider
+        sb.AppendLine();
+        for (var i = 0; i < _columns.Length; i++)
+        {
+            sb.Append(new string('-', maxWidths[i]));
+            if (i < _columns.Length - 1)
+            {
+                sb.Append("-+-");
+            }
+        }
+
+        sb.AppendLine();
+        return sb.ToString();
+    }
+}

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLoginCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLoginCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
-[Command("cloud login", Description = "Log into the Meadow Service")]
+[Command("cloud login", Description = "Log in to Meadow.Cloud")]
 public class CloudLoginCommand : BaseCloudCommand<CloudLoginCommand>
 {
     [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLogoutCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLogoutCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
-[Command("cloud logout", Description = "Log out of the Meadow Service")]
+[Command("cloud logout", Description = "Log out of Meadow.Cloud")]
 public class CloudLogoutCommand : BaseCloudCommand<CloudLogoutCommand>
 {
     public CloudLogoutCommand(

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
@@ -7,11 +7,11 @@ using System.Text.Json;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
-[Command("cloud command publish", Description = "Publish a command to Meadow devices via the Meadow Service")]
+[Command("cloud command publish", Description = "Publish a command to Meadow devices via Meadow.Cloud")]
 public class CloudCommandPublishCommand : BaseCloudCommand<CloudCommandPublishCommand>
 {
     [CommandParameter(0, Description = "The name of the command", IsRequired = true, Name = "COMMAND_NAME")]
-    public string CommandName { get; set; } = default!;
+    public string CommandName { get; set; } = string.Empty;
 
     [CommandOption("collectionId", 'c', Description = "The target collection for publishing the command")]
     public string? CollectionId { get; set; }
@@ -64,12 +64,11 @@ public class CloudCommandPublishCommand : BaseCloudCommand<CloudCommandPublishCo
 
         try
         {
-            Logger?.LogInformation($"Publishing '{CommandName}' command to Meadow.Cloud. Please wait...");
             if (!string.IsNullOrWhiteSpace(CollectionId))
             {
                 await CommandService.PublishCommandForCollection(CollectionId, CommandName, Arguments, (int)QualityOfService, Host, CancellationToken);
             }
-            else if (DeviceIds.Any())
+            else if (DeviceIds?.Length > 0)
             {
                 await CommandService.PublishCommandForDevices(DeviceIds, CommandName, Arguments, (int)QualityOfService, Host, CancellationToken);
             }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageListCommand.cs
@@ -14,7 +14,7 @@ public class CloudPackageListCommand : BaseCloudCommand<CloudPackageListCommand>
     public string? OrgId { get; set; }
 
     [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
-    public string Host { get; set; }
+    public string? Host { get; set; }
 
     public CloudPackageListCommand(
         IdentityManager identityManager,

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackagePublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackagePublishCommand.cs
@@ -11,16 +11,16 @@ public class CloudPackagePublishCommand : BaseCloudCommand<CloudPackagePublishCo
     private readonly PackageService _packageService;
 
     [CommandParameter(0, Name = "PackageID", Description = "ID of the package to publish", IsRequired = true)]
-    public string PackageId { get; init; }
+    public string PackageId { get; init; } = string.Empty;
 
     [CommandOption("collectionId", 'c', Description = "The target collection for publishing", IsRequired = true)]
-    public string CollectionId { get; set; }
+    public string CollectionId { get; set; } = string.Empty;
 
     [CommandOption("metadata", 'm', Description = "Pass through metadata", IsRequired = false)]
-    public string Metadata { get; set; }
+    public string? Metadata { get; set; }
 
     [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
-    public string Host { get; set; }
+    public string? Host { get; set; }
 
     public CloudPackagePublishCommand(
         IdentityManager identityManager,
@@ -42,8 +42,8 @@ public class CloudPackagePublishCommand : BaseCloudCommand<CloudPackagePublishCo
         {
             Logger?.LogInformation($"Publishing package {PackageId} to collection {CollectionId}...");
 
-            await _packageService.PublishPackage(PackageId, CollectionId, Metadata, Host, CancellationToken);
-            Logger?.LogInformation("Publish successful");
+            await _packageService.PublishPackage(PackageId, CollectionId, Metadata ?? string.Empty, Host, CancellationToken);
+            Logger?.LogInformation("Publish successful.");
         }
         catch (MeadowCloudException mex)
         {

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageUploadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageUploadCommand.cs
@@ -9,7 +9,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class CloudPackageUploadCommand : BaseCloudCommand<CloudPackageUploadCommand>
 {
     [CommandParameter(0, Name = "MpakPath", Description = "The full path of the mpak file", IsRequired = true)]
-    public string MpakPath { get; init; }
+    public string MpakPath { get; init; } = string.Empty;
 
     [CommandOption("orgId", 'o', Description = "OrgId to upload to", IsRequired = false)]
     public string? OrgId { get; set; }

--- a/Source/v2/Meadow.Cli/Program.cs
+++ b/Source/v2/Meadow.Cli/Program.cs
@@ -55,6 +55,7 @@ public class Program
         services.AddSingleton<CollectionService>();
         services.AddSingleton<CommandService>();
         services.AddSingleton<PackageService>();
+        services.AddSingleton<ApiTokenService>();
         services.AddSingleton<IdentityManager, IdentityManager>();
 
         if (File.Exists("appsettings.json"))

--- a/Source/v2/Meadow.Cloud.Client/Services/ApiTokenService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/ApiTokenService.cs
@@ -1,0 +1,117 @@
+﻿﻿using Meadow.Cloud;
+using Meadow.Cloud.Identity;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace Meadow.Cloud;
+
+public class ApiTokenService : CloudServiceBase
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public ApiTokenService(IdentityManager identityManager) : base(identityManager)
+    {
+    }
+
+    public async Task<IEnumerable<GetApiTokenResponse>> GetApiTokens(string host, CancellationToken? cancellationToken)
+    {
+        var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
+        var response = await httpClient.GetAsync($"{host}/api/auth/tokens", cancellationToken ?? CancellationToken.None);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var message = await response.Content.ReadAsStringAsync();
+            throw new MeadowCloudException(message);
+        }
+
+        return await response.Content.ReadFromJsonAsync<IEnumerable<GetApiTokenResponse>>(JsonSerializerOptions, cancellationToken ?? CancellationToken.None)
+            ?? Enumerable.Empty<GetApiTokenResponse>();
+    }
+
+    public async Task<CreateApiTokenResponse> CreateApiToken(CreateApiTokenRequest request, string host, CancellationToken? cancellationToken)
+    {
+        var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
+        var content = new StringContent(JsonSerializer.Serialize(request, JsonSerializerOptions), Encoding.UTF8, "application/json");
+        var response = await httpClient.PostAsync($"{host}/api/auth/tokens", content, cancellationToken ?? CancellationToken.None);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var message = await response.Content.ReadAsStringAsync();
+            throw new MeadowCloudException(message);
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<CreateApiTokenResponse>(JsonSerializerOptions, cancellationToken ?? CancellationToken.None);
+        return result!;
+    }
+
+    public async Task<UpdateApiTokenResponse> UpdateApiToken(string id, UpdateApiTokenRequest request, string host, CancellationToken? cancellationToken)
+    {
+        var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
+        var content = new StringContent(JsonSerializer.Serialize(request, JsonSerializerOptions), Encoding.UTF8, "application/json");
+        var response = await httpClient.PutAsync($"{host}/api/auth/tokens/{id}", content, cancellationToken ?? CancellationToken.None);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var message = await response.Content.ReadAsStringAsync();
+            throw new MeadowCloudException(message);
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<UpdateApiTokenResponse>(JsonSerializerOptions, cancellationToken ?? CancellationToken.None);
+        return result!;
+    }
+
+    public async Task DeleteApiToken(string id, string host, CancellationToken? cancellationToken)
+    {
+        var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
+        var response = await httpClient.DeleteAsync($"{host}/api/auth/tokens/{id}", cancellationToken ?? CancellationToken.None);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var message = await response.Content.ReadAsStringAsync();
+            throw new MeadowCloudException(message);
+        }
+    }
+}
+
+public record GetApiTokenResponse(
+    string Id,
+    string Name,
+    DateTimeOffset ExpiresAt,
+    string[] Scopes
+)
+{ }
+
+public record CreateApiTokenRequest
+(
+    string Name,
+    int Duration,
+    string[] Scopes
+)
+{ }
+
+public record CreateApiTokenResponse
+(
+    string Id,
+    string Name,
+    DateTimeOffset ExpiresAt,
+    string[] Scopes,
+    string Token
+)
+{ }
+
+public record UpdateApiTokenRequest
+(
+    string Name,
+    string[] Scopes
+)
+{ }
+
+public record UpdateApiTokenResponse
+(
+    string Id,
+    string Name,
+    DateTimeOffset ExpiresAt,
+    string[] Scopes
+)
+{ }

--- a/Source/v2/Meadow.Cloud.Client/Services/CommandService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/CommandService.cs
@@ -6,11 +6,8 @@ namespace Meadow.Cloud;
 
 public class CommandService : CloudServiceBase
 {
-    private readonly IdentityManager _identityManager;
-
     public CommandService(IdentityManager identityManager) : base(identityManager)
     {
-        _identityManager = identityManager;
     }
 
     public async Task PublishCommandForCollection(


### PR DESCRIPTION
This adds the ability to manage your Meadow.Cloud API keys via the command line (V2 only).

The commands are:
```
meadow cloud apikey create <NAME> --duration|d <duration> --scopes|s <scopes>
meadow cloud apikey list
meadow cloud apikey update <NAME_OR_ID> --name|n <name> --scopes|s <scopes>
meadow cloud apikey delete <NAME_OR_ID>
```

This also utilizes the new Console spinner and implements a new `ConsoleTable` for displaying tabular data.

## Examples

### Create

```
> meadow cloud api create myapikey --duration 30 --scopes command
Creating an API key on Meadow.Cloud...
Your API key 'myapikey' (expiring 1/26/2024 5:40:30 PM UTC) is:

mc_xxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

Make sure to copy this key now as you will not be able to see this again.
Done.
```

### Update

```
❯ meadow cloud apikey update myapikey --scopes command search
Updating API key `myapikey` on Meadow.Cloud...
Done.
```

### Delete

```
❯ meadow cloud apikey delete myapikey
Deleting API key `myapikey` on Meadow.Cloud...
Done.
```

### List

#### When you have no API keys

```
❯ meadow cloud apikey list
Retrieving your API keys from Meadow.Cloud...
You have no API keys.
Done.
```

#### When you have a single API key

```
❯ meadow cloud apikey list
Retrieving your API keys from Meadow.Cloud...

---------------------------------+----------+----------------------+----------------
Id                               | Name     | Expires (UTC)        | Scopes
---------------------------------|----------|----------------------|----------------
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx | myapikey | 1/26/2024 5:44:33 PM | command, search
---------------------------------+----------+----------------------+----------------

Done.
```