### PR TITLE
Change PDBs inclusion default to false

### DIFF
--- a/Meadow.CLI.Core/Devices/MeadowDeviceHelper.cs
+++ b/Meadow.CLI.Core/Devices/MeadowDeviceHelper.cs
@@ -243,7 +243,7 @@ namespace Meadow.CLI.Core.Devices
             return _meadowDevice.QspiInit(value, cancellationToken);
         }
 
-        public async Task DeployApp(string fileName, bool includePdbs = true, CancellationToken cancellationToken = default, bool verbose = false, IList<string>? noLink = null)
+        public async Task DeployApp(string fileName, bool includePdbs = false, CancellationToken cancellationToken = default, bool verbose = false, IList<string>? noLink = null)
         {
             try
             {

--- a/Meadow.CLI/Commands/App/DeployAppCommand.cs
+++ b/Meadow.CLI/Commands/App/DeployAppCommand.cs
@@ -27,7 +27,7 @@ namespace Meadow.CLI.Commands.App
         public IList<string> NoLink { get; init; } = null;
 
         [CommandOption("includePdbs", 'i', Description = "Include the PDB files on deploy to enable debugging", IsRequired = false)]
-        public bool IncludePdbs { get; init; } = true;
+        public bool IncludePdbs { get; init; } = false;
 
         public DeployAppCommand(DownloadManager downloadManager, ILoggerFactory loggerFactory, MeadowDeviceManager meadowDeviceManager)
             : base(downloadManager, loggerFactory, meadowDeviceManager)


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow_Issues/issues/376

Given that the PDBs are not needed for most users, since they are not necessary for basic app debugging, making the PDBs inclusion default to false should make the deployment faster, and save storage space. 