### PR TITLE
Fix Debug.WriteLine exception issue

### DIFF
--- a/Meadow.CLI.Core/lib/meadow_link.xml
+++ b/Meadow.CLI.Core/lib/meadow_link.xml
@@ -8,4 +8,5 @@
     <assembly fullname="Meadow.Logging" />
     <assembly fullname="SQLite-net" />
     <assembly fullname="MQTTnet" />
+    <assembly fullname="System.Configuration" />
 </linker>


### PR DESCRIPTION
- https://github.com/WildernessLabs/Meadow_Issues/issues/3

Skipping the `System.Configuration` trimming fixes the `Debug.WriteLine()` exception. It increases the `.dll` size by ~60kB, which seems like an acceptable workaround side effect.