### PR TITLE
Update command parameters and options to be more consistent

### DIFF
--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
@@ -10,15 +10,15 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class CloudApiKeyCreateCommand : BaseCloudCommand<CloudApiKeyCreateCommand>
 {
     [CommandParameter(0, Description = "The name of the API key", IsRequired = true, Name = "NAME")]
-    public string? Name { get; set; }
+    public string Name { get; init; } = default!;
 
     [CommandOption("duration", 'd', Description = "The duration of the API key, in days", IsRequired = true)]
-    public int Duration { get; set; }
+    public int Duration { get; init; } = default!;
 
     [CommandOption("scopes", 's', Description = "The list of scopes (permissions) to grant the API key", IsRequired = true)]
-    public string[]? Scopes { get; set; }
+    public string[] Scopes { get; init; } = default!;
 
-    [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})")]
+    [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]
     public string? Host { get; set; }
 
     private ApiTokenService ApiTokenService { get; }

--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
@@ -10,7 +10,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class CloudApiKeyDeleteCommand : BaseCloudCommand<CloudApiKeyDeleteCommand>
 {
     [CommandParameter(0, Description = "The name or ID of the API key", IsRequired = true, Name = "NAME_OR_ID")]
-    public string? NameOrId { get; set; }
+    public string NameOrId { get; init; } = default!;
 
     [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]
     public string? Host { get; set; }

--- a/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
@@ -10,12 +10,12 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class CloudApiKeyUpdateCommand : BaseCloudCommand<CloudApiKeyUpdateCommand>
 {
     [CommandParameter(0, Description = "The name or ID of the API key", IsRequired = true, Name = "NAME_OR_ID")]
-    public string? NameOrId { get; set; }
+    public string NameOrId { get; init; } = default!;
 
-    [CommandOption("name", 'n', Description = "The new name to use for the API key")]
+    [CommandOption("name", 'n', Description = "The new name to use for the API key", IsRequired = false)]
     public string? NewName { get; set; }
 
-    [CommandOption("scopes", 's', Description = "The list of scopes (permissions) to grant the API key")]
+    [CommandOption("scopes", 's', Description = "The list of scopes (permissions) to grant the API key", IsRequired = false)]
     public string[]? Scopes { get; set; }
 
     [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
@@ -12,7 +12,7 @@ public class AppBuildCommand : BaseCommand<AppBuildCommand>
     public string? Configuration { get; set; }
 
     [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
-    public string? Path { get; set; } = default!;
+    public string? Path { get; init; }
 
     public AppBuildCommand(IPackageManager packageManager, ILoggerFactory loggerFactory)
         : base(loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppDebugCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppDebugCommand.cs
@@ -9,7 +9,7 @@ public class AppDebugCommand : BaseDeviceCommand<AppDebugCommand>
     // VS 2019 - 4024
     // VS 2017 - 4022
     // VS 2015 - 4020
-    [CommandOption("Port", 'p', Description = "The port to run the debug server on")]
+    [CommandOption("Port", 'p', Description = "The port to run the debug server on", IsRequired = false)]
     public int Port { get; init; } = 4024;
 
     public AppDebugCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
@@ -10,7 +10,7 @@ public class AppDeployCommand : BaseDeviceCommand<AppDeployCommand>
     private readonly IPackageManager _packageManager;
 
     [CommandParameter(0, Name = "Path to folder containing the built application", IsRequired = false)]
-    public string? Path { get; set; } = default!;
+    public string? Path { get; init; }
 
     public AppDeployCommand(IPackageManager packageManager, MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
@@ -10,14 +10,14 @@ public class AppRunCommand : BaseDeviceCommand<AppRunCommand>
     private readonly IPackageManager _packageManager;
     private string? _lastFile;
 
-    [CommandOption("no-prefix", 'n', IsRequired = false, Description = "When set, the message source prefix (e.g. 'stdout>') is suppressed during 'listen'")]
-    public bool NoPrefix { get; set; }
+    [CommandOption("no-prefix", 'n', Description = "When set, the message source prefix (e.g. 'stdout>') is suppressed during 'listen'", IsRequired = false)]
+    public bool NoPrefix { get; init; }
 
     [CommandOption('c', Description = "The build configuration to compile", IsRequired = false)]
     public string? Configuration { get; set; }
 
     [CommandParameter(0, Name = "Path to folder containing the built application", IsRequired = false)]
-    public string? Path { get; set; } = default!;
+    public string? Path { get; init; }
 
     public AppRunCommand(IPackageManager packageManager, MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
@@ -9,10 +9,10 @@ public class AppTrimCommand : BaseCommand<AppTrimCommand>
     private readonly IPackageManager _packageManager;
 
     [CommandOption('c', Description = "The build configuration to trim", IsRequired = false)]
-    public string? Configuration { get; set; }
+    public string? Configuration { get; init; }
 
     [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
-    public string? Path { get; set; } = default!;
+    public string? Path { get; init; }
 
     public AppTrimCommand(IPackageManager packageManager, ILoggerFactory loggerFactory)
         : base(loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Collection/CloudCollectionListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Collection/CloudCollectionListCommand.cs
@@ -10,8 +10,9 @@ public class CloudCollectionListCommand : BaseCloudCommand<CloudCollectionListCo
 {
     [CommandOption("host", 'h', Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]
     public string? Host { get; set; }
+
     [CommandOption("orgId", 'o', Description = "Organization Id", IsRequired = false)]
-    public string? OrgId { get; set; }
+    public string? OrgId { get; init; }
 
     public CloudCollectionListCommand(
         IdentityManager identityManager,
@@ -25,6 +26,7 @@ public class CloudCollectionListCommand : BaseCloudCommand<CloudCollectionListCo
     protected override async ValueTask ExecuteCommand()
     {
         Host ??= DefaultHost;
+
         var org = await ValidateOrg(Host, OrgId, CancellationToken);
 
         if (org == null) return;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
@@ -11,21 +11,21 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class CloudCommandPublishCommand : BaseCloudCommand<CloudCommandPublishCommand>
 {
     [CommandParameter(0, Description = "The name of the command", IsRequired = true, Name = "COMMAND_NAME")]
-    public string CommandName { get; set; } = string.Empty;
+    public string CommandName { get; init; } = default!;
 
-    [CommandOption("collectionId", 'c', Description = "The target collection for publishing the command")]
-    public string? CollectionId { get; set; }
+    [CommandOption("collectionId", 'c', Description = "The target collection for publishing the command", IsRequired = false)]
+    public string? CollectionId { get; init; }
 
-    [CommandOption("deviceIds", 'd', Description = "The target devices for publishing the command")]
-    public string[]? DeviceIds { get; set; }
+    [CommandOption("deviceIds", 'd', Description = "The target devices for publishing the command", IsRequired = false)]
+    public string[]? DeviceIds { get; init; }
 
-    [CommandOption("args", 'a', Description = "The arguments for the command as a JSON string", Converter = typeof(JsonDocumentBindingConverter))]
-    public JsonDocument? Arguments { get; set; }
+    [CommandOption("args", 'a', Description = "The arguments for the command as a JSON string", Converter = typeof(JsonDocumentBindingConverter), IsRequired = false)]
+    public JsonDocument? Arguments { get; init; }
 
-    [CommandOption("qos", 'q', Description = "The MQTT-defined quality of service for the command")]
-    public QualityOfService QualityOfService { get; set; } = QualityOfService.AtLeastOnce;
+    [CommandOption("qos", 'q', Description = "The MQTT-defined quality of service for the command", IsRequired = false)]
+    public QualityOfService QualityOfService { get; init; } = QualityOfService.AtLeastOnce;
 
-    [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)")]
+    [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
     public string? Host { get; set; }
 
     private CommandService CommandService { get; }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
@@ -10,13 +10,13 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class CloudPackageCreateCommand : BaseCloudCommand<CloudPackageCreateCommand>
 {
     [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
-    public string? ProjectPath { get; set; } = default!;
+    public string? ProjectPath { get; set; }
 
     [CommandOption('c', Description = "The build configuration to compile", IsRequired = false)]
-    public string Configuration { get; set; } = "Release";
+    public string Configuration { get; init; } = "Release";
 
     [CommandOption("name", 'n', Description = "Name of the mpak file to be created", IsRequired = false)]
-    public string? MpakName { get; init; } = default!;
+    public string? MpakName { get; init; }
 
     [CommandOption("filter", 'f', Description = "Glob pattern to filter files. ex ('app.dll', 'app*','{app.dll,meadow.dll}')",
         IsRequired = false)]

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageListCommand.cs
@@ -11,7 +11,7 @@ public class CloudPackageListCommand : BaseCloudCommand<CloudPackageListCommand>
     private readonly PackageService _packageService;
 
     [CommandOption("orgId", 'o', Description = "Optional organization ID", IsRequired = false)]
-    public string? OrgId { get; set; }
+    public string? OrgId { get; init; }
 
     [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
     public string? Host { get; set; }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackagePublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackagePublishCommand.cs
@@ -11,13 +11,13 @@ public class CloudPackagePublishCommand : BaseCloudCommand<CloudPackagePublishCo
     private readonly PackageService _packageService;
 
     [CommandParameter(0, Name = "PackageID", Description = "ID of the package to publish", IsRequired = true)]
-    public string PackageId { get; init; } = string.Empty;
+    public string PackageId { get; init; } = default!;
 
     [CommandOption("collectionId", 'c', Description = "The target collection for publishing", IsRequired = true)]
-    public string CollectionId { get; set; } = string.Empty;
+    public string CollectionId { get; init; } = default!;
 
     [CommandOption("metadata", 'm', Description = "Pass through metadata", IsRequired = false)]
-    public string? Metadata { get; set; }
+    public string? Metadata { get; init; }
 
     [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
     public string? Host { get; set; }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageUploadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageUploadCommand.cs
@@ -9,13 +9,13 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class CloudPackageUploadCommand : BaseCloudCommand<CloudPackageUploadCommand>
 {
     [CommandParameter(0, Name = "MpakPath", Description = "The full path of the mpak file", IsRequired = true)]
-    public string MpakPath { get; init; } = string.Empty;
+    public string MpakPath { get; init; } = default!;
 
     [CommandOption("orgId", 'o', Description = "OrgId to upload to", IsRequired = false)]
-    public string? OrgId { get; set; }
+    public string? OrgId { get; init; }
 
     [CommandOption("description", 'd', Description = "Description of the package", IsRequired = false)]
-    public string? Description { get; set; }
+    public string? Description { get; init; }
 
     [CommandOption("host", Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
     public string? Host { get; set; }

--- a/Source/v2/Meadow.Cli/Commands/Current/Config/ConfigCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Config/ConfigCommand.cs
@@ -8,10 +8,10 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class ConfigCommand : BaseSettingsCommand<ConfigCommand>
 {
     [CommandOption("list", IsRequired = false)]
-    public bool List { get; set; }
+    public bool List { get; init; }
 
     [CommandParameter(0, Name = "Settings", IsRequired = false)]
-    public string[]? Settings { get; set; }
+    public string[]? Settings { get; init; }
 
     public ConfigCommand(ISettingsManager settingsManager, ILoggerFactory? loggerFactory)
         : base(settingsManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/DeveloperCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/DeveloperCommand.cs
@@ -6,11 +6,11 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 [Command("developer", Description = "Sets a specified developer parameter on the Meadow")]
 public class DeveloperCommand : BaseDeviceCommand<DeveloperCommand>
 {
-    [CommandOption("param", 'p', Description = "The parameter to set.")]
-    public ushort Parameter { get; set; }
+    [CommandOption("param", 'p', Description = "The parameter to set.", IsRequired = false)]
+    public ushort Parameter { get; init; }
 
-    [CommandOption("value", 'v', Description = "The value to apply to the parameter. Valid values are 0 to 4,294,967,295")]
-    public uint Value { get; set; }
+    [CommandOption("value", 'v', Description = "The value to apply to the parameter. Valid values are 0 to 4,294,967,295", IsRequired = false)]
+    public uint Value { get; init; }
 
     public DeveloperCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/Device/DeviceClockCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Device/DeviceClockCommand.cs
@@ -7,7 +7,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class DeviceClockCommand : BaseDeviceCommand<DeviceInfoCommand>
 {
     [CommandParameter(0, Name = "Time", IsRequired = false)]
-    public string? Time { get; set; }
+    public string? Time { get; init; }
 
     public DeviceClockCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/Device/DeviceProvisionCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Device/DeviceProvisionCommand.cs
@@ -16,10 +16,10 @@ public class DeviceProvisionCommand : BaseDeviceCommand<DeviceProvisionCommand>
     public string? OrgId { get; set; }
 
     [CommandOption("collectionId", 'c', Description = "The target collection for device registration", IsRequired = false)]
-    public string? CollectionId { get; set; }
+    public string? CollectionId { get; init; }
 
     [CommandOption("name", 'n', Description = "Device friendly name", IsRequired = false)]
-    public string? Name { get; set; }
+    public string? Name { get; init; }
 
     [CommandOption("host", 'h', Description = "Optionally set a host (default is https://www.meadowcloud.co)", IsRequired = false)]
     public string? Host { get; set; }
@@ -36,7 +36,7 @@ public class DeviceProvisionCommand : BaseDeviceCommand<DeviceProvisionCommand>
 
         try
         {
-            if (Host == null) Host = DefaultHost;
+            Host ??= DefaultHost;
 
             var identityManager = new IdentityManager(Logger);
             var _userService = new UserService(identityManager);

--- a/Source/v2/Meadow.Cli/Commands/Current/File/FileDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/File/FileDeleteCommand.cs
@@ -7,7 +7,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class FileDeleteCommand : BaseDeviceCommand<FileDeleteCommand>
 {
     [CommandParameter(0, Name = "MeadowFile", IsRequired = true)]
-    public string MeadowFile { get; set; } = default!;
+    public string MeadowFile { get; init; } = default!;
 
     public FileDeleteCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/File/FileInitialCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/File/FileInitialCommand.cs
@@ -7,7 +7,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class FileInitialCommand : BaseDeviceCommand<FileInitialCommand>
 {
     [CommandParameter(0, Name = "MeadowFile", IsRequired = true)]
-    public string MeadowFile { get; set; } = default!;
+    public string MeadowFile { get; init; } = default!;
 
     public FileInitialCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/File/FileListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/File/FileListCommand.cs
@@ -9,10 +9,10 @@ public class FileListCommand : BaseDeviceCommand<FileListCommand>
     public const int FileSystemBlockSize = 4096;
 
     [CommandOption("verbose", 'v', IsRequired = false)]
-    public bool Verbose { get; set; }
+    public bool Verbose { get; init; }
 
     [CommandParameter(0, Name = "Folder", IsRequired = false)]
-    public string? Folder { get; set; } = default!;
+    public string? Folder { get; set; }
 
     public FileListCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/File/FileReadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/File/FileReadCommand.cs
@@ -7,10 +7,10 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class FileReadCommand : BaseDeviceCommand<FileReadCommand>
 {
     [CommandParameter(0, Name = "MeadowFile", IsRequired = true)]
-    public string MeadowFile { get; set; } = default!;
+    public string MeadowFile { get; init; } = default!;
 
     [CommandParameter(1, Name = "LocalFile", IsRequired = false)]
-    public string? LocalFile { get; set; }
+    public string? LocalFile { get; init; }
 
     public FileReadCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/File/FileWriteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/File/FileWriteCommand.cs
@@ -16,7 +16,8 @@ public class FileWriteCommand : BaseDeviceCommand<FileWriteCommand>
     [CommandOption(
         "targetFiles",
         't',
-        Description = "The filename(s) to use on the Meadow File System")]
+        Description = "The filename(s) to use on the Meadow File System",
+        IsRequired = false)]
     public IList<string> TargetFileNames { get; init; } = Array.Empty<string>();
 
     public FileWriteCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
@@ -12,7 +12,7 @@ public class FirmwareDefaultCommand : BaseFileCommand<FirmwareDefaultCommand>
     { }
 
     [CommandParameter(0, Name = "Version number to use as default", IsRequired = false)]
-    public string? Version { get; set; } = null;
+    public string? Version { get; init; }
 
     protected override async ValueTask ExecuteCommand()
     {

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
@@ -12,7 +12,7 @@ public class FirmwareDeleteCommand : BaseFileCommand<FirmwareDeleteCommand>
     { }
 
     [CommandParameter(0, Name = "Version number to delete", IsRequired = true)]
-    public string Version { get; set; } = default!;
+    public string Version { get; init; } = default!;
 
     protected override async ValueTask ExecuteCommand()
     {

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
@@ -12,10 +12,10 @@ public class FirmwareDownloadCommand : BaseFileCommand<FirmwareDownloadCommand>
     { }
 
     [CommandOption("force", 'f', IsRequired = false)]
-    public bool Force { get; set; }
+    public bool Force { get; init; }
 
     [CommandOption("version", 'v', IsRequired = false)]
-    public string? Version { get; set; } = default!;
+    public string? Version { get; set; }
 
     protected override async ValueTask ExecuteCommand()
     {

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareListCommand.cs
@@ -8,7 +8,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class FirmwareListCommand : BaseCommand<FirmwareListCommand>
 {
     [CommandOption("verbose", 'v', IsRequired = false)]
-    public bool Verbose { get; set; }
+    public bool Verbose { get; init; }
 
     private FileManager FileManager { get; }
 

--- a/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/ListenCommand.cs
@@ -6,8 +6,8 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 [Command("listen", Description = "Listen for console output from Meadow")]
 public class ListenCommand : BaseDeviceCommand<ListenCommand>
 {
-    [CommandOption("no-prefix", 'n', IsRequired = false, Description = "When set, the message source prefix (e.g. 'stdout>') is suppressed")]
-    public bool NoPrefix { get; set; }
+    [CommandOption("no-prefix", 'n', Description = "When set, the message source prefix (e.g. 'stdout>') is suppressed", IsRequired = false)]
+    public bool NoPrefix { get; init; }
 
     public ListenCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/Trace/TraceLevelCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Trace/TraceLevelCommand.cs
@@ -7,7 +7,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 public class TraceLevelCommand : BaseDeviceCommand<TraceLevelCommand>
 {
     [CommandParameter(0, Name = "Level", IsRequired = true)]
-    public int Level { get; set; }
+    public int Level { get; init; }
 
     public TraceLevelCommand(MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)
         : base(connectionManager, loggerFactory)


### PR DESCRIPTION
This updates the command parameters and options to be more consistent. This entails required properties to non-nullable with a default value of `default!`, `IsRequired` to be explicitly defined, and properties should use `{ get; init; }` unless they are being updated.