### PR TITLE
[v2] Update meadow firmware download command to use Meadow Cloud

### DIFF
--- a/Source/v2/Meadow.CLI/Meadow.CLI.csproj
+++ b/Source/v2/Meadow.CLI/Meadow.CLI.csproj
@@ -34,6 +34,7 @@
 		<PackageReference Include="Serilog" Version="3.0.1" />
 		<PackageReference Include="CliFx" Version="*" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
 		<PackageReference Include="System.Management" Version="7.0.2" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />

--- a/Source/v2/Meadow.Cli/Commands/Legacy/DownloadOsCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Legacy/DownloadOsCommand.cs
@@ -1,4 +1,5 @@
 ﻿using CliFx.Attributes;
+using Meadow.Cloud.Identity;
 using Meadow.Software;
 using Microsoft.Extensions.Logging;
 
@@ -7,8 +8,8 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 [Command("download os", Description = "** Deprecated ** Use `firmware download` instead")]
 public class DownloadOsCommand : FirmwareDownloadCommand
 {
-    public DownloadOsCommand(FileManager fileManager, ISettingsManager settingsManager, ILoggerFactory loggerFactory)
-        : base(fileManager, settingsManager, loggerFactory)
+    public DownloadOsCommand(FileManager fileManager, IdentityManager identityManager, ISettingsManager settingsManager, ILoggerFactory loggerFactory)
+        : base(fileManager, identityManager, settingsManager, loggerFactory)
     {
         Logger?.LogWarning($"Deprecated command - use `firmware download` instead");
     }

--- a/Source/v2/Meadow.Cli/Program.cs
+++ b/Source/v2/Meadow.Cli/Program.cs
@@ -6,9 +6,14 @@ using Meadow.Cloud.Identity;
 using Meadow.Software;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http;
 using Serilog;
 using Serilog.Events;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Meadow.SoftwareManager")]
 
 public class Program
 {
@@ -57,6 +62,14 @@ public class Program
         services.AddSingleton<PackageService>();
         services.AddSingleton<ApiTokenService>();
         services.AddSingleton<IdentityManager, IdentityManager>();
+
+        services.AddHttpClient<FileManager>(c =>
+        {
+            c.Timeout = TimeSpan.FromMinutes(5);
+        });
+
+        // Required to disable console logging of HttpClient
+        services.RemoveAll<IHttpMessageHandlerBuilderFilter>();
 
         if (File.Exists("appsettings.json"))
         {

--- a/Source/v2/Meadow.SoftwareManager.Unit.Tests/Builders/FakeableHttpMessageHandler.cs
+++ b/Source/v2/Meadow.SoftwareManager.Unit.Tests/Builders/FakeableHttpMessageHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Meadow.SoftwareManager.Unit.Tests.Builders;
+
+public abstract class FakeableHttpMessageHandler : HttpMessageHandler
+{
+    public abstract Task<HttpResponseMessage> FakeSendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken);
+
+    // sealed so FakeItEasy won't intercept calls to this method
+    protected sealed override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+        => FakeSendAsync(request, cancellationToken);
+}

--- a/Source/v2/Meadow.SoftwareManager.Unit.Tests/Builders/MeadowCloudClientBuilder.cs
+++ b/Source/v2/Meadow.SoftwareManager.Unit.Tests/Builders/MeadowCloudClientBuilder.cs
@@ -1,0 +1,73 @@
+﻿using FakeItEasy;
+using Meadow.Software;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace Meadow.SoftwareManager.Unit.Tests.Builders;
+
+public class MeadowCloudClientBuilder
+{
+    private readonly Dictionary<(string Type, string Version), F7ReleaseMetadata> _firmware = new();
+    private readonly Dictionary<(string Type, string Version), HttpResponseMessage> _firmwareResponses = new();
+
+    public MeadowCloudClientBuilder WithFirmware(string type, string version)
+    {
+        _firmware[(type, version)] = new F7ReleaseMetadata
+        {
+            Version = version,
+            MinCLIVersion = version,
+            DownloadURL = $"https://example.org/api/v1/firmware/{type}/Meadow.OS_{version}.zip",
+            NetworkDownloadURL = $"https://example.org/api/v1/firmware/{type}/Meadow.Network_{version}.zip"
+        };
+        return this;
+    }
+
+    public MeadowCloudClientBuilder WithFirmwareReference(string type, string version, string referencedVersion)
+    {
+        if (_firmware.TryGetValue((type, referencedVersion), out F7ReleaseMetadata? referencedMetadata))
+        {
+            _firmware[(type, version)] = referencedMetadata;
+            return this;
+        }
+
+        return WithFirmware(type, version);
+    }
+
+    public MeadowCloudClientBuilder WithFirmwareResponse(string type, string version, HttpResponseMessage httpResponseMessage)
+    {
+        _firmwareResponses[(type, version)] = httpResponseMessage;
+        return this;
+    }
+
+    public HttpClient Build()
+    {
+        var handler = A.Fake<FakeableHttpMessageHandler>();
+
+        A.CallTo(() => handler
+            .FakeSendAsync(A<HttpRequestMessage>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+        foreach (var ((type, version), metadata) in _firmware)
+        {
+            A.CallTo(() => handler
+                .FakeSendAsync(
+                    A<HttpRequestMessage>.That.Matches(r => r.RequestUri!.AbsolutePath == $"/api/v1/firmware/{type}/{version}"),
+                    A<CancellationToken>.Ignored))
+                .Returns(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(metadata)
+                });
+        }
+
+        foreach (var ((type, version), response) in _firmwareResponses)
+        {
+            A.CallTo(() => handler
+                .FakeSendAsync(
+                    A<HttpRequestMessage>.That.Matches(r => r.RequestUri!.AbsolutePath == $"/api/v1/firmware/{type}/{version}"),
+                    A<CancellationToken>.Ignored))
+                .Returns(response);
+        }
+
+        return new HttpClient(handler) { BaseAddress = new Uri("https://example.org") };
+    }
+}

--- a/Source/v2/Meadow.SoftwareManager.Unit.Tests/F7CollectionTests.cs
+++ b/Source/v2/Meadow.SoftwareManager.Unit.Tests/F7CollectionTests.cs
@@ -7,7 +7,7 @@ public class F7CollectionTests
     [Fact]
     public void TestCollectionPopulation()
     {
-        var collection = new F7FirmwarePackageCollection(F7FirmwarePackageCollection.DefaultF7FirmwareStoreRoot);
+        var collection = new F7FirmwarePackageCollection(new HttpClient(), F7FirmwarePackageCollection.DefaultF7FirmwareStoreRoot);
 
         collection.Refresh();
     }

--- a/Source/v2/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetLatestAvailableVersionTests.cs
+++ b/Source/v2/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetLatestAvailableVersionTests.cs
@@ -1,0 +1,42 @@
+﻿using Meadow.Software;
+using Meadow.SoftwareManager.Unit.Tests.Builders;
+
+namespace Meadow.SoftwareManager.Unit.Tests.F7FirmwareDownloadManagerTests;
+
+public class GetLatestAvailableVersionTests
+{
+    [Fact]
+    public async Task GetLatestAvailableVersion_WithLatestVersionFound_ShouldReturnVersion()
+    {
+        // Arrange
+        var client = new MeadowCloudClientBuilder()
+            .WithFirmware("Meadow_Beta", "1.8.0.0")
+            .WithFirmware("Meadow_Beta", "1.7.0.0")
+            .WithFirmwareReference("Meadow_Beta", "latest", "1.8.0.0")
+            .Build();
+        var downloadManager = new F7FirmwareDownloadManager(client);
+
+        // Act
+        var result = await downloadManager.GetLatestAvailableVersion();
+
+        // Assert
+        Assert.Equal("1.8.0.0", result);
+    }
+
+    [Fact]
+    public async Task GetLatestAvailableVersion_WithLatestVersionNotFound_ShouldReturnEmptyString()
+    {
+        // Arrange
+        var client = new MeadowCloudClientBuilder()
+            .WithFirmware("Meadow_Beta", "1.8.0.0")
+            .WithFirmware("Meadow_Beta", "1.7.0.0")
+            .Build();
+        var downloadManager = new F7FirmwareDownloadManager(client);
+
+        // Act
+        var result = await downloadManager.GetLatestAvailableVersion();
+
+        // Assert
+        Assert.Equal("", result);
+    }
+}

--- a/Source/v2/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetReleaseMetadataTests.cs
+++ b/Source/v2/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetReleaseMetadataTests.cs
@@ -1,0 +1,107 @@
+﻿using Meadow.Software;
+using Meadow.SoftwareManager.Unit.Tests.Builders;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Meadow.SoftwareManager.Unit.Tests.F7FirmwareDownloadManagerTests;
+
+public class GetReleaseMetadataTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetReleaseMetadata_WithNullOrWhiteSpaceVersion_ShouldReturnLatestVersion(string? version)
+    {
+        // Arrange
+        var client = new MeadowCloudClientBuilder()
+            .WithFirmware("Meadow_Beta", "1.8.0.0")
+            .WithFirmware("Meadow_Beta", "1.7.0.0")
+            .WithFirmwareReference("Meadow_Beta", "latest", "1.8.0.0")
+            .Build();
+        var downloadManager = new F7FirmwareDownloadManager(client);
+
+        // Act
+        var result = await downloadManager.GetReleaseMetadata(version);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("1.8.0.0", result.Version);
+    }
+
+    [Fact]
+    public async Task GetReleaseMetadata_WithSpecificVersion_ShouldReturnVersion()
+    {
+        // Arrange
+        var client = new MeadowCloudClientBuilder()
+            .WithFirmware("Meadow_Beta", "1.8.0.0")
+            .WithFirmware("Meadow_Beta", "1.7.0.0")
+            .WithFirmwareReference("Meadow_Beta", "latest", "1.8.0.0")
+            .Build();
+        var downloadManager = new F7FirmwareDownloadManager(client);
+
+        // Act
+        var result = await downloadManager.GetReleaseMetadata("1.7.0.0");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("1.7.0.0", result.Version);
+    }
+
+    [Fact]
+    public async Task GetReleaseMetadata_WithUnknownVersion_ShouldReturnNull()
+    {
+        // Arrange
+        var client = new MeadowCloudClientBuilder()
+            .WithFirmware("Meadow_Beta", "1.8.0.0")
+            .WithFirmware("Meadow_Beta", "1.7.0.0")
+            .WithFirmwareReference("Meadow_Beta", "latest", "1.8.0.0")
+            .Build();
+        var downloadManager = new F7FirmwareDownloadManager(client);
+
+        // Act
+        var result = await downloadManager.GetReleaseMetadata("1.6.0.0");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetReleaseMetadata_WithVersionThatReturnsErrorResponse_ShouldReturnNull()
+    {
+        // Arrange
+        var client = new MeadowCloudClientBuilder()
+            .WithFirmwareResponse("Meadow_Beta", "1.8.0.0", new HttpResponseMessage(HttpStatusCode.InternalServerError))
+            .Build();
+        var downloadManager = new F7FirmwareDownloadManager(client);
+
+        // Act
+        var result = await downloadManager.GetReleaseMetadata("1.8.0.0");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetReleaseMetadata_WithVersionThatReturnsTextResponse_ShouldReturnNull()
+    {
+        // Arrange
+        var client = new MeadowCloudClientBuilder()
+            .WithFirmwareResponse("Meadow_Beta", "1.8.0.0", new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("This is content.")
+            })
+            .Build();
+        var downloadManager = new F7FirmwareDownloadManager(client);
+
+        // Act
+        var result = await downloadManager.GetReleaseMetadata("1.8.0.0");
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/Source/v2/Meadow.SoftwareManager.Unit.Tests/Meadow.SoftwareManager.Unit.Tests.csproj
+++ b/Source/v2/Meadow.SoftwareManager.Unit.Tests/Meadow.SoftwareManager.Unit.Tests.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="8.1.0" />
+    <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FakeItEasy.Extensions.ValueTask" Version="8.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/Source/v2/Meadow.SoftwareManager/F7FirmwarePackageCollection.cs
+++ b/Source/v2/Meadow.SoftwareManager/F7FirmwarePackageCollection.cs
@@ -3,8 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
-
 
 namespace Meadow.Software;
 
@@ -24,9 +24,10 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
         "WildernessLabs",
         "Firmware");
     private FirmwarePackage? _defaultPackage;
+    private F7FirmwareDownloadManager _downloadManager;
 
-    internal F7FirmwarePackageCollection()
-        : this(DefaultF7FirmwareStoreRoot)
+    internal F7FirmwarePackageCollection(HttpClient meadowCloudClient)
+        : this(meadowCloudClient, DefaultF7FirmwareStoreRoot)
     {
     }
 
@@ -34,8 +35,10 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
 
     public FirmwarePackage this[int index] => _f7Packages[index];
 
-    internal F7FirmwarePackageCollection(string rootPath)
+    internal F7FirmwarePackageCollection(HttpClient meadowCloudClient, string rootPath)
     {
+        _downloadManager = new F7FirmwareDownloadManager(meadowCloudClient);
+
         if (!Directory.Exists(rootPath))
         {
             Directory.CreateDirectory(rootPath);
@@ -60,9 +63,7 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
     /// <returns>A version number if an update is available, otherwise null</returns>
     public async Task<string?> UpdateAvailable()
     {
-        var downloadManager = new F7FirmwareDownloadManager();
-
-        var latestVersion = await downloadManager.GetLatestAvailableVersion();
+        var latestVersion = await _downloadManager.GetLatestAvailableVersion();
 
         var existing = _f7Packages.FirstOrDefault(p => p.Version == latestVersion);
 
@@ -113,15 +114,12 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
             throw new ArgumentException($"Version '{version}' not found locally.");
         }
 
-        var downloadManager = new F7FirmwareDownloadManager();
-        downloadManager.SetDefaultVersion(PackageFileRoot, version);
+        _downloadManager.SetDefaultVersion(PackageFileRoot, version);
     }
 
     public async Task<bool> IsVersionAvailableForDownload(string version)
     {
-        var downloadManager = new F7FirmwareDownloadManager();
-
-        var meta = await downloadManager.GetReleaseMetadata(version);
+        var meta = await _downloadManager.GetReleaseMetadata(version);
 
         if (meta == null) return false;
         if (meta.Version != string.Empty) return true;
@@ -131,9 +129,7 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
 
     public async Task<string?> GetLatestAvailableVersion()
     {
-        var downloadManager = new F7FirmwareDownloadManager();
-
-        var meta = await downloadManager.GetReleaseMetadata();
+        var meta = await _downloadManager.GetReleaseMetadata();
 
         if (meta == null) return null;
         if (meta.Version == string.Empty) return null;
@@ -143,24 +139,22 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
 
     public async Task<bool> RetrievePackage(string version, bool overwrite = false)
     {
-        var downloadManager = new F7FirmwareDownloadManager();
-
         void ProgressHandler(object sender, long e)
         {
             DownloadProgress?.Invoke(this, e);
         }
 
-        downloadManager.DownloadProgress += ProgressHandler;
+        _downloadManager.DownloadProgress += ProgressHandler;
         try
         {
-            var meta = await downloadManager.GetReleaseMetadata(version);
+            var meta = await _downloadManager.GetReleaseMetadata(version);
             if (meta == null) return false;
 
-            return await downloadManager.DownloadRelease(PackageFileRoot, version, overwrite);
+            return await _downloadManager.DownloadRelease(PackageFileRoot, version, overwrite);
         }
         finally
         {
-            downloadManager.DownloadProgress -= ProgressHandler;
+            _downloadManager.DownloadProgress -= ProgressHandler;
         }
     }
 

--- a/Source/v2/Meadow.SoftwareManager/FileManager.cs
+++ b/Source/v2/Meadow.SoftwareManager/FileManager.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
-
 
 namespace Meadow.Software;
 
@@ -23,11 +23,14 @@ public class FileManager
 
     public FirmwareStore Firmware { get; }
 
-    public FileManager()
+    public HttpClient MeadowCloudClient { get; }
+
+    public FileManager(HttpClient meadowCloudClient)
     {
         Firmware = new FirmwareStore();
-        var f7Collection = new F7FirmwarePackageCollection();
+        var f7Collection = new F7FirmwarePackageCollection(meadowCloudClient);
         Firmware.AddCollection("Meadow F7", f7Collection);
+        MeadowCloudClient = meadowCloudClient;
     }
 
     public async Task Refresh()

--- a/Source/v2/Meadow.SoftwareManager/Meadow.SoftwareManager.csproj
+++ b/Source/v2/Meadow.SoftwareManager/Meadow.SoftwareManager.csproj
@@ -1,12 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
-	  <LangVersion>10</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
     <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This updates the **v2** version of `meadow firmware download` to retrieve the Meadow firmware from Meadow.Cloud. From the user's perspective the only change is that it **_will require a user to have a Meadow.Cloud account_** and for that user to login with `meadow cloud login`. The only additional command-line option is the `--host` argument:

```
USAGE
  meadow firmware download [options]

DESCRIPTION
  Download a firmware package

OPTIONS
  -f|--force        Default: "False".
  -v|--version
  --host            Optionally set a host (default is https://www.meadowcloud.co)
  -h|--help         Shows help text.
```

## Example

An example of this command would be:

```
C:\>meadow login
Logging into https://www.meadowcloud.co...
Signed in as user@example.org
Done

C:\>meadow firmware download
Retrieving firmware information from Meadow.Cloud...
Latest available version is '1.8.0.0'...
Downloading firmware package '1.8.0.0'...
Firmware package '1.8.0.0' downloaded
```

An example if the user is not logged in:
```
C:\>meadow firmware download
Retrieving firmware information from Meadow.Cloud...
You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.
```