### PR TITLE
[v2] Fix command publishing

### DIFF
--- a/Source/v2/Meadow.Cli/Program.cs
+++ b/Source/v2/Meadow.Cli/Program.cs
@@ -49,14 +49,14 @@ public class Program
         services.AddSingleton<FileManager>();
         services.AddSingleton<ISettingsManager, SettingsManager>();
         services.AddSingleton<IPackageManager, PackageManager>();
-
         services.AddSingleton<UserService>();
         services.AddSingleton<DeviceService>();
         services.AddSingleton<CollectionService>();
         services.AddSingleton<CommandService>();
         services.AddSingleton<PackageService>();
         services.AddSingleton<ApiTokenService>();
-        services.AddSingleton<IdentityManager, IdentityManager>();
+        services.AddSingleton<IdentityManager>();
+        services.AddSingleton<JsonDocumentBindingConverter>();
 
         if (File.Exists("appsettings.json"))
         {


### PR DESCRIPTION
This fixes a bug with v2 of Meadow.CLI when attempting to publish a Meadow.Cloud command to a device with the `--args` argument specified. This adds the `JsonDocumentBindingConverter` type to the services collection dependency container.

Without this fix, the following error occurs if arguments are specified:

> Failed to create an instance of type `Meadow.CLI.Commands.DeviceManagement.JsonDocumentBindingConverter`, received \<null\> instead.
To fix this, ensure that the provided type activator is configured correctly, as it's not expected to return \<null\>.
If you are relying on a dependency container, this error may indicate that the specified type has not been registered.