### PR TITLE
Add quotes to path used to build project

### DIFF
--- a/Meadow.CLI.Core/Managers/PackageManager.cs
+++ b/Meadow.CLI.Core/Managers/PackageManager.cs
@@ -45,7 +45,7 @@ namespace Meadow.CLI.Core
         {
             var proc = new Process();
             proc.StartInfo.FileName = "dotnet";
-            proc.StartInfo.Arguments = $"build {projectPath}";
+            proc.StartInfo.Arguments = $"build \"{projectPath}\"";
 
             proc.StartInfo.CreateNoWindow = true;
             proc.StartInfo.ErrorDialog = false;

--- a/Source/v2/Meadow.Package/PackageManager.cs
+++ b/Source/v2/Meadow.Package/PackageManager.cs
@@ -80,7 +80,7 @@ public partial class PackageManager : IPackageManager
 
         var proc = new Process();
         proc.StartInfo.FileName = "dotnet";
-        proc.StartInfo.Arguments = $"build {projectFilePath} -c {configuration}";
+        proc.StartInfo.Arguments = $"build \"{projectFilePath}\" -c {configuration}";
 
         proc.StartInfo.CreateNoWindow = true;
         proc.StartInfo.ErrorDialog = false;


### PR DESCRIPTION
Package create builds the project. It takes a path to the .csproj file. The path may contain spaces and needs quotes.