### PR TITLE
Throw DirectoryNotFoundException when !Directory.Exists()

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
@@ -43,6 +43,11 @@ public class CloudPackageCreateCommand : BaseCloudCommand<CloudPackageCreateComm
     protected override async ValueTask ExecuteCommand()
     {
         ProjectPath ??= AppDomain.CurrentDomain.BaseDirectory;
+        ProjectPath = Path.GetFullPath(ProjectPath);
+        if (!Directory.Exists(ProjectPath))
+        {
+            throw new DirectoryNotFoundException($"Directory not found '{ProjectPath}'. Check path to project file.");
+        }
 
         // build
         Logger?.LogInformation($"Building {Configuration} version of application...");

--- a/Source/v2/Meadow.Package/PackageManager.cs
+++ b/Source/v2/Meadow.Package/PackageManager.cs
@@ -4,7 +4,9 @@ using Meadow.Linker;
 using Meadow.Software;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.IO.Compression;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using YamlDotNet.Serialization;
@@ -227,7 +229,8 @@ public partial class PackageManager : IPackageManager
 
     public static FileInfo[] GetAvailableBuiltConfigurations(string rootFolder, string appName = "App.dll")
     {
-        if (!Directory.Exists(rootFolder)) { throw new FileNotFoundException(); }
+        rootFolder = Path.GetFullPath(rootFolder);
+        if (!Directory.Exists(rootFolder)) { throw new DirectoryNotFoundException($"Directory not found '{rootFolder}'. Check path to project file."); }
 
         //see if this is a fully qualified path to the app.dll
         if (File.Exists(Path.Combine(rootFolder, appName)))
@@ -237,7 +240,7 @@ public partial class PackageManager : IPackageManager
 
         // look for a 'bin' folder
         var path = Path.Combine(rootFolder, "bin");
-        if (!Directory.Exists(path)) throw new FileNotFoundException($"No 'bin' directory found under {rootFolder}. Have you compiled?");
+        if (!Directory.Exists(path)) throw new DirectoryNotFoundException($"No 'bin' directory found under '{rootFolder}'. Have you compiled?");
 
         var files = new List<FileInfo>();
         FindApp(path, files);


### PR DESCRIPTION
PackageManager.cs was throwing a misleading FileNotFoundException when a directory was not found. 

Similar in CloudPackageCreateCommand. 

For extra resilience, get the full path to the user supplied folder before checking if it exists. This works around the challenge of the difference between v1 (expects parameter pointing to .csproj) and v2 (expects folder with single .csproj)