### PR TITLE
Add support to set created mpak file name from CLI

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
@@ -73,7 +73,7 @@ public class CloudPackageCreateCommand : BaseCloudCommand<CloudPackageCreateComm
         var postlinkDir = Path.Combine(file.Directory?.FullName ?? string.Empty, PackageManager.PostLinkDirectoryName);
 
         Logger?.LogInformation($"Assembling the MPAK...");
-        var packagePath = await _packageManager.AssemblePackage(postlinkDir, packageDir, osVersion, Filter, true, CancellationToken);
+        var packagePath = await _packageManager.AssemblePackage(postlinkDir, packageDir, osVersion, MpakName, Filter, true, CancellationToken);
 
         if (packagePath != null)
         {

--- a/Source/v2/Meadow.Package/IPackageManager.cs
+++ b/Source/v2/Meadow.Package/IPackageManager.cs
@@ -16,10 +16,10 @@ public interface IPackageManager
         IList<string>? noLink = null,
         CancellationToken? cancellationToken = null);
 
-    Task<string> AssemblePackage(
-        string contentSourceFolder,
+    Task<string> AssemblePackage(string contentSourceFolder,
         string outputFolder,
         string osVersion,
+        string? mpakName = null,
         string filter = "*",
         bool overwrite = false,
         CancellationToken? cancellationToken = null);

--- a/Source/v2/Meadow.Package/PackageManager.cs
+++ b/Source/v2/Meadow.Package/PackageManager.cs
@@ -163,10 +163,10 @@ public partial class PackageManager : IPackageManager
 
     public const string PackageMetadataFileName = "info.json";
 
-    public Task<string> AssemblePackage(
-        string contentSourceFolder,
+    public Task<string> AssemblePackage(string contentSourceFolder,
         string outputFolder,
         string osVersion,
+        string? mpakName = null,
         string filter = "*",
         bool overwrite = false,
         CancellationToken? cancellationToken = null)
@@ -177,7 +177,8 @@ public partial class PackageManager : IPackageManager
             di.Create();
         }
 
-        var mpakName = Path.Combine(outputFolder, $"{DateTime.UtcNow:yyyyMMddff}.mpak");
+        // uncomment to force ".mpak" extension. mpakName = Path.ChangeExtension(mpakName, ".mpak");
+        mpakName = Path.Combine(outputFolder, string.IsNullOrWhiteSpace(mpakName) ? $"{DateTime.UtcNow:yyyyMMddff}.mpak" : mpakName);
 
         if (File.Exists(mpakName))
         {


### PR DESCRIPTION
There is an existing -n option which sets the property MpakPath. This value needs to be passed into the method creating the mpak. Default value to null which will can be checked to then automatically assign a file name using DateTime.