### PR TITLE
README: Split firmware download locations to own lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ dotnet tool install WildernessLabs.Meadow.CLI --global
 
 If you need to find or clear out any of the OS download files retrieved by Meadow.CLI, they are located in a WildernessLabs folder in the user directory.
 
-macOS: `~/.local/share/WildernessLabs/Firmware/`
-Windows: `%LOCALAPPDATA%\WildernessLabs\Firmware`
+* macOS: `~/.local/share/WildernessLabs/Firmware/`
+* Windows: `%LOCALAPPDATA%\WildernessLabs\Firmware`


### PR DESCRIPTION
Just a quick fix for this, that also allows us to add any other OS locations in the future.