### PR TITLE
Improve usage of logger and command exception

### DIFF
--- a/Source/v2/Meadow.Cli/CommandErrors.cs
+++ b/Source/v2/Meadow.Cli/CommandErrors.cs
@@ -1,11 +1,10 @@
-﻿namespace Meadow.CLI
+﻿namespace Meadow.CLI;
+
+public enum CommandExitCode
 {
-    public enum CommandErrors
-    {
-        Success = 0,
-        GeneralError = 1,
-        UserCancelled = 2,
-        FileNotFound = 3,
-        DirectoryNotFound = 4,
-    }
+    Success = 0,
+    GeneralError = 1,
+    UserCancelled = 2,
+    FileNotFound = 3,
+    DirectoryNotFound = 4,
 }

--- a/Source/v2/Meadow.Cli/CommandException.cs
+++ b/Source/v2/Meadow.Cli/CommandException.cs
@@ -1,0 +1,37 @@
+﻿namespace Meadow.CLI;
+
+/// <inheritdoc/>
+public class CommandException : CliFx.Exceptions.CommandException
+{
+    public CommandException(string message)
+        : base(message, (int)CommandExitCode.GeneralError, showHelp: false, innerException: null)
+    { }
+
+    public CommandException(string message, bool showHelp)
+        : base(message, (int)CommandExitCode.GeneralError, showHelp, innerException: null)
+    { }
+
+    public CommandException(string message, CommandExitCode exitCode)
+        : base(message, (int)exitCode, showHelp: false, innerException: null)
+    { }
+
+    public CommandException(string message, CommandExitCode exitCode, bool showHelp)
+        : base(message, (int)exitCode, showHelp, innerException: null)
+    { }
+
+    public CommandException(string message, Exception innerException)
+        : base(message, (int)CommandExitCode.GeneralError, showHelp: false, innerException)
+    { }
+
+    public CommandException(string message, bool showHelp, Exception innerException)
+        : base(message, (int)CommandExitCode.GeneralError, showHelp, innerException)
+    { }
+
+    public CommandException(string message, CommandExitCode exitCode, Exception innerException)
+        : base(message, (int)exitCode, showHelp: false, innerException: innerException)
+    { }
+
+    public CommandException(string message, CommandExitCode exitCode, bool showHelp, Exception innerException)
+        : base(message, (int)exitCode, showHelp, innerException: innerException)
+    { }
+}

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Package;
 using Microsoft.Extensions.Logging;
 
@@ -32,7 +31,7 @@ public class AppBuildCommand : BaseCommand<AppBuildCommand>
             // is it a valid directory?
             if (!Directory.Exists(path))
             {
-                throw new CommandException($"Invalid application path '{path}'", (int)CommandErrors.FileNotFound);
+                throw new CommandException($"Invalid application path '{path}'", CommandExitCode.FileNotFound);
             }
         }
 
@@ -45,7 +44,7 @@ public class AppBuildCommand : BaseCommand<AppBuildCommand>
 
         if (!success)
         {
-            throw new CommandException($"Build failed.", (int)CommandErrors.GeneralError);
+            throw new CommandException("Build failed", CommandExitCode.GeneralError);
         }
         else
         {

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Hcom;
 using Meadow.Package;
 using Microsoft.Extensions.Logging;
@@ -37,7 +36,7 @@ public class AppRunCommand : BaseDeviceCommand<AppRunCommand>
             // is it a valid directory?
             if (!Directory.Exists(path))
             {
-                throw new CommandException($"Invalid application path '{path}'", (int)CommandErrors.FileNotFound);
+                throw new CommandException($"Invalid application path '{path}'", CommandExitCode.FileNotFound);
             }
         }
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Identity;
 using Microsoft.Extensions.Logging;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Identity;
 using Microsoft.Extensions.Logging;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Identity;
 using Microsoft.Extensions.Logging;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Identity;
 using Microsoft.Extensions.Logging;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Collection/JsonDocumentBindingConverter.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Collection/JsonDocumentBindingConverter.cs
@@ -1,5 +1,4 @@
-﻿using CliFx.Exceptions;
-using CliFx.Extensibility;
+﻿using CliFx.Extensibility;
 using System.Text.Json;
 
 namespace Meadow.CLI.Commands.DeviceManagement;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Identity;
 using Microsoft.Extensions.Logging;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Identity;
 using Meadow.Package;
@@ -47,21 +46,21 @@ public class CloudPackageCreateCommand : BaseCloudCommand<CloudPackageCreateComm
         ProjectPath = Path.GetFullPath(ProjectPath);
         if (!Directory.Exists(ProjectPath))
         {
-            throw new CommandException($"Directory not found '{ProjectPath}'. Check path to project file.", (int)CommandErrors.DirectoryNotFound);
+            throw new CommandException($"Directory not found '{ProjectPath}'. Check path to project file.", CommandExitCode.DirectoryNotFound);
         }
 
         // build
         Logger?.LogInformation($"Building {Configuration} version of application...");
         if (!_packageManager.BuildApplication(ProjectPath, Configuration, true, CancellationToken))
         {
-            throw new CommandException($"Build failed.", (int)CommandErrors.GeneralError);
+            throw new CommandException($"Build failed");
         }
 
         var candidates = PackageManager.GetAvailableBuiltConfigurations(ProjectPath, "App.dll");
 
         if (candidates.Length == 0)
         {
-            throw new CommandException($"Cannot find a compiled application at '{ProjectPath}'", (int)CommandErrors.FileNotFound);
+            throw new CommandException($"Cannot find a compiled application at '{ProjectPath}'", CommandExitCode.FileNotFound);
         }
 
         var store = _fileManager.Firmware["Meadow F7"];
@@ -86,7 +85,7 @@ public class CloudPackageCreateCommand : BaseCloudCommand<CloudPackageCreateComm
         }
         else
         {
-            throw new CommandException($"Package assembly failed.", (int)CommandErrors.GeneralError);
+            throw new CommandException($"Package assembly failed");
         }
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/Config/ConfigCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Config/ConfigCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;

--- a/Source/v2/Meadow.Cli/Commands/Legacy/FlashOsCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Legacy/FlashOsCommand.cs
@@ -1,5 +1,4 @@
 ﻿using CliFx.Attributes;
-using CliFx.Exceptions;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;


### PR DESCRIPTION
This improves the use of Logger, LoggerFactory, and Console by removing the nullable references which eliminates the need for the null conditional operators. This also creates a new `CommandException` that is able to take in `CommandExitCode` (formerly `CommandErrors`) instead of having to cast to `int` everywhere.

The one note is if `Console` is used _before_ the `ExecuteCommand()` method, an exception will be thrown with the message, "The Console property has not yet been initialized. It can only be used within in the ExecuteCommand() method."