### PR TITLE
LogError when build fails

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
@@ -63,11 +63,13 @@ public class AppRunCommand : BaseDeviceCommand<AppRunCommand>
 
         if (!await BuildApplication(path, CancellationToken))
         {
+            Logger?.LogError("Build Failed.");
             return;
         }
 
         if (!await TrimApplication(path, CancellationToken))
         {
+            Logger?.LogError("Trim Failed.");
             return;
         }
 
@@ -76,6 +78,7 @@ public class AppRunCommand : BaseDeviceCommand<AppRunCommand>
 
         if (!await DeployApplication(connection, path, CancellationToken))
         {
+            Logger?.LogError("Deploy Application Failed.");
             return;
         }
 


### PR DESCRIPTION
Add minimum LogError messages to inform user when 'app run' command exits. 

Specifically needed when the project fails to build as the Meadow.CLI simple exits to the command prompt without giving any indication why it stopped. Added others for completeness. 

