### PR TITLE
Update login verbiage to use Wilderness Labs account

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
@@ -59,8 +59,7 @@ public abstract class BaseCloudCommand<T> : BaseCommand<T>
         }
         catch (MeadowCloudAuthException)
         {
-            Logger?.LogError($"You must be signed in to execute this command.");
-            Logger?.LogError($"Please run \"meadow cloud login\" to sign in to Meadow.Cloud.");
+            Logger?.LogError($"You must be signed into your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");
         }
 
         return null;

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
@@ -48,7 +48,7 @@ public class CloudApiKeyCreateCommand : BaseCloudCommand<CloudApiKeyCreateComman
         var token = await IdentityManager.GetAccessToken(CancellationToken);
         if (string.IsNullOrWhiteSpace(token))
         {
-            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+            throw new CommandException("You must be signed into your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");
         }
 
         try

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
@@ -37,7 +37,7 @@ public class CloudApiKeyDeleteCommand : BaseCloudCommand<CloudApiKeyDeleteComman
         var token = await IdentityManager.GetAccessToken(CancellationToken);
         if (string.IsNullOrWhiteSpace(token))
         {
-            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+            throw new CommandException("You must be signed into your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");
         }
 
         try

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
@@ -34,7 +34,7 @@ public class CloudApiKeyListCommand : BaseCloudCommand<CloudApiKeyListCommand>
         var token = await IdentityManager.GetAccessToken(CancellationToken);
         if (string.IsNullOrWhiteSpace(token))
         {
-            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+            throw new CommandException("You must be signed your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");
         }
 
         try

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
@@ -43,7 +43,7 @@ public class CloudApiKeyUpdateCommand : BaseCloudCommand<CloudApiKeyUpdateComman
         var token = await IdentityManager.GetAccessToken(CancellationToken);
         if (string.IsNullOrWhiteSpace(token))
         {
-            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+            throw new CommandException("You must be signed your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");
         }
 
         try

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLoginCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLoginCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
-[Command("cloud login", Description = "Log in to Meadow.Cloud")]
+[Command("cloud login", Description = "Log in to your Wilderness Labs account")]
 public class CloudLoginCommand : BaseCloudCommand<CloudLoginCommand>
 {
     [CommandOption("host", Description = $"Optionally set a host (default is {DefaultHost})", IsRequired = false)]
@@ -24,7 +24,7 @@ public class CloudLoginCommand : BaseCloudCommand<CloudLoginCommand>
     {
         Host ??= DefaultHost;
 
-        Logger?.LogInformation($"Logging into {Host}...");
+        Logger?.LogInformation($"Logging into you Wilderness Labs account...");
 
         var loginResult = await IdentityManager.Login(Host, CancellationToken);
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLogoutCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLogoutCommand.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
-[Command("cloud logout", Description = "Log out of Meadow.Cloud")]
+[Command("cloud logout", Description = "Log out of your Wilderness Labs account")]
 public class CloudLogoutCommand : BaseCloudCommand<CloudLogoutCommand>
 {
     public CloudLogoutCommand(
@@ -19,7 +19,7 @@ public class CloudLogoutCommand : BaseCloudCommand<CloudLogoutCommand>
 
     protected override ValueTask ExecuteCommand()
     {
-        Logger?.LogInformation($"Logging out of Meadow.Cloud...");
+        Logger?.LogInformation($"Logging out of your Wilderness Labs account...");
 
         IdentityManager.Logout();
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
@@ -58,7 +58,7 @@ public class CloudCommandPublishCommand : BaseCloudCommand<CloudCommandPublishCo
         var token = await IdentityManager.GetAccessToken(CancellationToken);
         if (string.IsNullOrWhiteSpace(token))
         {
-            throw new CommandException("You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+            throw new CommandException("You must be signed into your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");
         }
 
         try

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
@@ -34,7 +34,7 @@ public class FirmwareDownloadCommand : BaseFileCommand<FirmwareDownloadCommand>
         var isAuthenticated = await _meadowCloudClient.Authenticate(Host, CancellationToken);
         if (!isAuthenticated)
         {
-            Logger?.LogError($"You must be signed into Meadow.Cloud to execute this command. Run 'meadow cloud login' to do so.");
+            Logger?.LogError($"You must be signed into your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");
             return;
         }
 

--- a/Source/v2/Meadow.Cli/Strings.cs
+++ b/Source/v2/Meadow.Cli/Strings.cs
@@ -11,7 +11,7 @@ public static class Strings
     public const string MemberOfMoreThanOneOrg = "You are a member of more than 1 organization. Please specify the desired orgId for this device provisioning.";
     public const string UnableToFindMatchingOrg = "Unable to find an organization with a Name or ID matching '{0}'";
     public const string MustBeSignedInRunMeadowLogin = $"You must be signed in to execute this command.\n"
-         + "Please run \"meadow login\" to sign in to your Wilderness Labs account.";
+         + "Please run \"meadow cloud login\" to sign in to your Wilderness Labs account.";
     public const string RequestingDevicePublicKey = "Requesting device public key (this will take a minute)...";
     public const string CouldNotRetrievePublicKey = "Could not retrieve device's public key";
     public const string DeviceReturnedInvalidPublicKey = "Device returned an invalid public key";


### PR DESCRIPTION
This updates the verbiage of "signed into Meadow.Cloud" to instead be "signed into your Wilderness Labs account."