### PR TITLE
Assign description text to Description property of CommandProperty

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppBuildCommand.cs
@@ -12,7 +12,7 @@ public class AppBuildCommand : BaseCommand<AppBuildCommand>
     [CommandOption('c', Description = "The build configuration to compile", IsRequired = false)]
     public string? Configuration { get; set; }
 
-    [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
+    [CommandParameter(0, Description = "Path to project file", IsRequired = false)]
     public string? Path { get; init; }
 
     public AppBuildCommand(IPackageManager packageManager, ILoggerFactory loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppDeployCommand.cs
@@ -9,7 +9,7 @@ public class AppDeployCommand : BaseDeviceCommand<AppDeployCommand>
 {
     private readonly IPackageManager _packageManager;
 
-    [CommandParameter(0, Name = "Path to folder containing the built application", IsRequired = false)]
+    [CommandParameter(0, Description = "Path to folder containing the built application", IsRequired = false)]
     public string? Path { get; init; }
 
     public AppDeployCommand(IPackageManager packageManager, MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppRunCommand.cs
@@ -17,7 +17,7 @@ public class AppRunCommand : BaseDeviceCommand<AppRunCommand>
     [CommandOption('c', Description = "The build configuration to compile", IsRequired = false)]
     public string? Configuration { get; set; }
 
-    [CommandParameter(0, Name = "Path to folder containing the application to build", IsRequired = false)]
+    [CommandParameter(0, Description = "Path to folder containing the application to build", IsRequired = false)]
     public string? Path { get; init; }
 
     public AppRunCommand(IPackageManager packageManager, MeadowConnectionManager connectionManager, ILoggerFactory loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/App/AppTrimCommand.cs
@@ -12,7 +12,7 @@ public class AppTrimCommand : BaseCommand<AppTrimCommand>
     [CommandOption('c', Description = "The build configuration to trim", IsRequired = false)]
     public string? Configuration { get; init; }
 
-    [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
+    [CommandParameter(0, Description = "Path to project file", IsRequired = false)]
     public string? Path { get; init; }
 
     public AppTrimCommand(IPackageManager packageManager, ILoggerFactory loggerFactory)

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageCreateCommand.cs
@@ -10,7 +10,7 @@ namespace Meadow.CLI.Commands.DeviceManagement;
 [Command("cloud package create", Description = "Create a Meadow Package (MPAK)")]
 public class CloudPackageCreateCommand : BaseCloudCommand<CloudPackageCreateCommand>
 {
-    [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
+    [CommandParameter(0, Description = "Path to project file", IsRequired = false)]
     public string? ProjectPath { get; set; }
 
     [CommandOption('c', Description = "The build configuration to compile", IsRequired = false)]

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDefaultCommand.cs
@@ -11,7 +11,7 @@ public class FirmwareDefaultCommand : BaseFileCommand<FirmwareDefaultCommand>
         : base(fileManager, settingsManager, loggerFactory)
     { }
 
-    [CommandParameter(0, Name = "Version number to use as default", IsRequired = false)]
+    [CommandParameter(0, Description = "Version number to use as default", IsRequired = false)]
     public string? Version { get; init; }
 
     protected override async ValueTask ExecuteCommand()

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDeleteCommand.cs
@@ -11,7 +11,7 @@ public class FirmwareDeleteCommand : BaseFileCommand<FirmwareDeleteCommand>
         : base(fileManager, settingsManager, loggerFactory)
     { }
 
-    [CommandParameter(0, Name = "Version number to delete", IsRequired = true)]
+    [CommandParameter(0, Description = "Version number to delete", IsRequired = true)]
     public string Version { get; init; } = default!;
 
     protected override async ValueTask ExecuteCommand()

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareWriteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareWriteCommand.cs
@@ -26,7 +26,7 @@ public class FirmwareWriteCommand : BaseDeviceCommand<FirmwareWriteCommand>
     [CommandOption("file", 'f', IsRequired = false, Description = "Send only the specified file")]
     public string? IndividualFile { get; set; }
 
-    [CommandParameter(0, Name = "Files to write", IsRequired = false)]
+    [CommandParameter(0, Description = "Files to write", IsRequired = false)]
     public FirmwareType[]? FirmwareFileTypes { get; set; } = default!;
 
     private FileManager FileManager { get; }


### PR DESCRIPTION
@ctacke In a few places the description text was assigned to the `Name` property of the `CommandParameter` attribute. This PR changes them to assign to  `Description` property.

Example: `Meadow.CLI\Source\v2\Meadow.CLI\Commands\Current\App\AppBuildCommand.cs`
```
    [CommandParameter(0, Name = "Path to project file", IsRequired = false)]
    public string? Path { get; init; }
```
