### PR TITLE
Refactor MeadowCloudClient library and remove host from authentication

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLoginCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/CloudLoginCommand.cs
@@ -26,7 +26,7 @@ public class CloudLoginCommand : BaseCloudCommand<CloudLoginCommand>
 
         Logger?.LogInformation($"Logging into you Wilderness Labs account...");
 
-        var loginResult = await IdentityManager.Login(Host, CancellationToken);
+        var loginResult = await IdentityManager.Login(CancellationToken);
 
         if (loginResult)
         {

--- a/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Firmware/FirmwareDownloadCommand.cs
@@ -31,7 +31,7 @@ public class FirmwareDownloadCommand : BaseFileCommand<FirmwareDownloadCommand>
 
     protected override async ValueTask ExecuteCommand()
     {
-        var isAuthenticated = await _meadowCloudClient.Authenticate(Host, CancellationToken);
+        var isAuthenticated = await _meadowCloudClient.Authenticate(CancellationToken);
         if (!isAuthenticated)
         {
             Logger?.LogError($"You must be signed into your Wilderness Labs account to execute this command. Run 'meadow cloud login' to do so.");

--- a/Source/v2/Meadow.Cloud.Client/Firmware/FirmwareClient.cs
+++ b/Source/v2/Meadow.Cloud.Client/Firmware/FirmwareClient.cs
@@ -2,11 +2,9 @@
 
 public class FirmwareClient : MeadowCloudClientBase, IFirmwareClient
 {
-    private readonly HttpClient _httpClient;
-
-    public FirmwareClient(HttpClient httpClient)
+    public FirmwareClient(MeadowCloudContext meadowCloudContext, ILogger logger) 
+        : base(meadowCloudContext, logger)
     {
-        _httpClient = httpClient;
     }
 
     public async Task<IEnumerable<GetFirmwareVersionsResponse>> GetVersions(string type, CancellationToken cancellationToken = default)
@@ -17,7 +15,7 @@ public class FirmwareClient : MeadowCloudClientBase, IFirmwareClient
         }
 
         using var request = CreateHttpRequestMessage(HttpMethod.Get, "api/v1/firmware/{0}", type);
-        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        using var response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -45,7 +43,7 @@ public class FirmwareClient : MeadowCloudClientBase, IFirmwareClient
         }
 
         using var request = CreateHttpRequestMessage(HttpMethod.Get, "api/v1/firmware/{0}/{1}", type, version);
-        using var response = await _httpClient.SendAsync(request, cancellationToken);
+        using var response = await HttpClient.SendAsync(request, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -67,14 +65,8 @@ public class FirmwareClient : MeadowCloudClientBase, IFirmwareClient
             throw new ArgumentException($"'{nameof(url)}' must be a URL that ends with '.zip'.", nameof(url));
         }
 
-        var baseAddress = _httpClient.BaseAddress?.ToString();
-        if (baseAddress != null && url.StartsWith(baseAddress))
-        {
-            url = url.Substring(baseAddress.Length);
-        }
-
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        var response = await _httpClient.SendAsync(request, cancellationToken);
+        using var request = CreateHttpRequestMessage(HttpMethod.Get, url);
+        var response = await HttpClient.SendAsync(request, cancellationToken);
 
         try
         {

--- a/Source/v2/Meadow.Cloud.Client/IMeadowCloudClient.cs
+++ b/Source/v2/Meadow.Cloud.Client/IMeadowCloudClient.cs
@@ -18,5 +18,9 @@ public interface IMeadowCloudClient
     IPackageClient Package { get; }
     IUserClient User { get; }
 
-    Task<bool> Authenticate(string? host = default, CancellationToken cancellationToken = default);
+    Task<bool> Authenticate(CancellationToken cancellationToken = default);
+
+    public AuthenticationHeaderValue? Authorization { get; set; }
+    public Uri BaseAddress { get; set; }
+    public MeadowCloudUserAgent UserAgent { get; set; }
 }

--- a/Source/v2/Meadow.Cloud.Client/Identity/IdentityManager.cs
+++ b/Source/v2/Meadow.Cloud.Client/Identity/IdentityManager.cs
@@ -23,7 +23,7 @@ public class IdentityManager
     /// Kick off login
     /// </summary>
     /// <returns></returns>
-    public async Task<bool> Login(string host, CancellationToken cancellationToken = default)
+    public async Task<bool> Login(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -42,7 +42,7 @@ public class IdentityManager
                 var context = await http.GetContextAsync();
                 var raw = context.Request.RawUrl;
                 context.Response.StatusCode = 302;
-                context.Response.AddHeader("Location", host);
+                context.Response.AddHeader("Location", "https://wldrn.es/cliauthed");
                 context.Response.Close();
 
                 var result = await client.ProcessResponseAsync(raw, state, cancellationToken: cancellationToken);

--- a/Source/v2/Meadow.Cloud.Client/MeadowCloudContext.cs
+++ b/Source/v2/Meadow.Cloud.Client/MeadowCloudContext.cs
@@ -1,0 +1,21 @@
+﻿namespace Meadow.Cloud.Client;
+
+public class MeadowCloudContext
+{
+    public HttpClient HttpClient { get; }
+    public AuthenticationHeaderValue? Authorization { get; set; }
+    public Uri BaseAddress { get; set; }
+    public MeadowCloudUserAgent UserAgent { get; set; }
+
+    public MeadowCloudContext(HttpClient httpClient, Uri baseAddress, MeadowCloudUserAgent userAgent)
+    {
+        HttpClient = httpClient;
+        BaseAddress = baseAddress;
+        UserAgent = userAgent;
+    }
+
+    public MeadowCloudContext(HttpClient httpClient, MeadowCloudUserAgent userAgent)
+        : this(httpClient, MeadowCloudClient.DefaultHostUri, userAgent)
+    {
+    }
+}

--- a/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/FirmwareClientTests/GetVersionTests.cs
+++ b/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/FirmwareClientTests/GetVersionTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Meadow.Cloud.Client.Unit.Tests.FirmwareClientTests;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meadow.Cloud.Client.Unit.Tests.FirmwareClientTests;
 
 public class GetVersionTests
 {
@@ -8,13 +10,14 @@ public class GetVersionTests
     public GetVersionTests()
     {
         _handler = A.Fake<FakeableHttpMessageHandler>();
-        var httpClient = new HttpClient(_handler) { BaseAddress = new Uri("https://example.org") };
+        var httpClient = new HttpClient(_handler);
 
         A.CallTo(() => _handler
            .FakeSendAsync(A<HttpRequestMessage>.Ignored, A<CancellationToken>.Ignored))
            .Returns(new HttpResponseMessage(HttpStatusCode.NotFound));
 
-        _firmwareClient = new FirmwareClient(httpClient);
+        var context = new MeadowCloudContext(httpClient, new Uri("https://example.org"), new MeadowCloudUserAgent("Meadow.Cloud.Client.Unit.Tests"));
+        _firmwareClient = new FirmwareClient(context, NullLogger.Instance);
     }
 
     [Theory]

--- a/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/FirmwareClientTests/GetVersionsTests.cs
+++ b/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/FirmwareClientTests/GetVersionsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Meadow.Cloud.Client.Unit.Tests.FirmwareClientTests;
+﻿using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Meadow.Cloud.Client.Unit.Tests.FirmwareClientTests;
 
 public class GetVersionsTests
 {
@@ -8,13 +10,14 @@ public class GetVersionsTests
     public GetVersionsTests()
     {
         _handler = A.Fake<FakeableHttpMessageHandler>();
-        var httpClient = new HttpClient(_handler) { BaseAddress = new Uri("https://example.org") };
+        var httpClient = new HttpClient(_handler);
 
         A.CallTo(() => _handler
            .FakeSendAsync(A<HttpRequestMessage>.Ignored, A<CancellationToken>.Ignored))
            .Returns(new HttpResponseMessage(HttpStatusCode.NotFound));
 
-        _firmwareClient = new FirmwareClient(httpClient);
+        var context = new MeadowCloudContext(httpClient, new Uri("https://example.org"), new MeadowCloudUserAgent("Meadow.Cloud.Client.Unit.Tests"));
+        _firmwareClient = new FirmwareClient(context, NullLogger.Instance);
     }
 
     [Theory]

--- a/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/MeadowCloudClientBaseTests.cs
+++ b/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/MeadowCloudClientBaseTests.cs
@@ -1,34 +1,31 @@
-﻿using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
-using System.Net;
-using System.Net.Mail;
+﻿using Microsoft.Extensions.Logging;
 using System.Text;
 
 namespace Meadow.Cloud.Client.Unit.Tests;
 
 public class MeadowCloudClientBaseTests
 {
-    public class MeadowCloudClientBaseUnderTest : MeadowCloudClientBase
+    public class MeadowCloudClientBaseUnderTest(MeadowCloudContext meadowCloudContext, ILogger logger) 
+        : MeadowCloudClientBase(meadowCloudContext, logger)
     {
-        public new Task EnsureSuccessfulStatusCode(HttpResponseMessage response, CancellationToken cancellationToken = default)
+        public static new Task EnsureSuccessfulStatusCode(HttpResponseMessage response, CancellationToken cancellationToken = default)
         {
-            return base.EnsureSuccessfulStatusCode(response, cancellationToken);
+            return MeadowCloudClientBase.EnsureSuccessfulStatusCode(response, cancellationToken);
         }
 
-        public new Task<TResult> ProcessResponse<TResult>(HttpResponseMessage response, CancellationToken cancellationToken = default)
+        public static new Task<TResult> ProcessResponse<TResult>(HttpResponseMessage response, CancellationToken cancellationToken = default)
         {
-            return base.ProcessResponse<TResult>(response, cancellationToken);
+            return MeadowCloudClientBase.ProcessResponse<TResult>(response, cancellationToken);
         }
     }
 
     public class TestResult { public string PropertyOne { get; set; } = string.Empty; }
 
-    private readonly MeadowCloudClientBaseUnderTest _clientBase = new();
-
     [Fact]
     public async Task EnsureSuccessfulStatusCode_WithNullResponse_ShouldThrowException()
     {
         // Act/Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(() => _clientBase.EnsureSuccessfulStatusCode(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => MeadowCloudClientBaseUnderTest.EnsureSuccessfulStatusCode(null!));
     }
 
     [Theory]
@@ -40,7 +37,7 @@ public class MeadowCloudClientBaseTests
         var response = new HttpResponseMessage(httpStatusCode);
 
         // Act
-        await _clientBase.EnsureSuccessfulStatusCode(response);
+        await MeadowCloudClientBaseUnderTest.EnsureSuccessfulStatusCode(response);
     }
 
     [Theory]
@@ -54,7 +51,7 @@ public class MeadowCloudClientBaseTests
         var response = new HttpResponseMessage(httpStatusCode) { Content = null };
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.EnsureSuccessfulStatusCode(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.EnsureSuccessfulStatusCode(response));
 
         // Assert
         Assert.NotNull(ex.Response);
@@ -79,7 +76,7 @@ Response:
         };
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.EnsureSuccessfulStatusCode(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.EnsureSuccessfulStatusCode(response));
 
         // Assert
         Assert.Equal("This is a string.", ex.Response);
@@ -93,7 +90,7 @@ Response:
         response.Headers.TryAddWithoutValidation("X-Test-Header", "TestValue");
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.EnsureSuccessfulStatusCode(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.EnsureSuccessfulStatusCode(response));
 
         // Assert
         Assert.Equal(response.Headers.ToDictionary(x => x.Key, x => x.Value), ex.Headers);
@@ -103,7 +100,7 @@ Response:
     public async Task ProcessResponse_WithNullResponse_ShouldThrowException()
     {
         // Act/Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(() => _clientBase.ProcessResponse<object>(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => MeadowCloudClientBaseUnderTest.ProcessResponse<object>(null!));
     }
 
     [Fact]
@@ -116,7 +113,7 @@ Response:
         };
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.ProcessResponse<object>(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.ProcessResponse<object>(response));
 
         // Assert
         Assert.Equal(@"Response was null which was not expected.
@@ -136,7 +133,7 @@ Response:
         };
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.ProcessResponse<object>(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.ProcessResponse<object>(response));
 
         // Assert
         Assert.Equal(@"Content-Type of response is 'text/plain' which is not supported for deserialization of the response body stream as System.Object. Content-Type must be 'application/json.'
@@ -156,7 +153,7 @@ This is a string.", ex.Message);
         };
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.ProcessResponse<object>(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.ProcessResponse<object>(response));
 
         // Assert
         Assert.Equal(@"Could not deserialize the response body stream as System.Object.
@@ -176,7 +173,7 @@ This is a string.", ex.Message);
         };
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.ProcessResponse<object>(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.ProcessResponse<object>(response));
 
         // Assert
         Assert.Equal(@"Response was null which was not expected.
@@ -199,7 +196,7 @@ Response:
         };
 
         // Act
-        var result = await _clientBase.ProcessResponse<TestResult>(response);
+        var result = await MeadowCloudClientBaseUnderTest.ProcessResponse<TestResult>(response);
 
         // Assert
         Assert.NotNull(result);
@@ -220,7 +217,7 @@ Response:
         };
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => _clientBase.ProcessResponse<object>(response));
+        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => MeadowCloudClientBaseUnderTest.ProcessResponse<object>(response));
 
         // Assert
         Assert.Equal(@$"{message}


### PR DESCRIPTION
This pull request includes various changes the way the Meadow.Cloud client library works. It includes:

* Removing the need to specify `host` when calling `MeadowCloudClient.Authenticate()`,
* Changing how BaseAddress, UserAgent header, and Authorization header are given to HttpClient. Instead of setting the DefaultRequestHeaders, a new `MeadowCloudContext` object is used to populate each individual request. That means the BaseAddress can be changed on `MeadowCloudClient` without any issues that normally affect `HttpClient`,
* And when running `meadow cloud login`, it will redirect to a new "You have logged into your Wilderness Labs account" page.