### PR TITLE
change help text for use port

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Legacy/UsePortCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Legacy/UsePortCommand.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
-[Command("use port", Description = "** Deprecated ** Use `config route` instead")]
+[Command("use port", Description = "** Deprecated ** Use `port select` (if connecting via serial port) or `config route` (if connecting via IP) instead")]
 public class UsePortCommand : BaseCommand<UsePortCommand>
 {
     private readonly ISettingsManager _settingsManager;


### PR DESCRIPTION
pointing folks to `port select` instead of `config route` by default.