### PR TITLE
Add support for Meadow.Cloud API keys

### DIFF
--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
@@ -3,6 +3,7 @@ using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Users;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
+using System.Text;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
@@ -71,8 +72,14 @@ public abstract class BaseCloudCommand<T> : BaseCommand<T>
         {
             if (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             {
-                throw new CommandException($"You are not authorized to perform this action. Please check that you have appropriate access"
-                    + (!string.IsNullOrWhiteSpace(ApiKey) ? ", your API key has the correct scope(s)," : "") + " and try again.", ex);
+                var sb = new StringBuilder("You are not authorized to perform this action. Please check that you have sufficient access");
+                if (!string.IsNullOrWhiteSpace(ApiKey))
+                {
+                    sb.Append(", that your API keys is valid with the correct scopes,");
+                }
+                sb.Append(" and try again.");
+
+                throw new CommandException(sb.ToString(), ex);
             }
 
             throw new CommandException($@"There was a problem executing the command. Meadow.Cloud returned a non-successful response.

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
@@ -2,6 +2,7 @@
 using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Users;
 using Microsoft.Extensions.Logging;
+using System.Net.Http.Headers;
 
 namespace Meadow.CLI.Commands.DeviceManagement;
 
@@ -9,6 +10,9 @@ public abstract class BaseCloudCommand<T> : BaseCommand<T>
 {
     [CommandOption("host", Description = $"The Meadow.Cloud endpoint.", IsRequired = false)]
     public string Host { get; set; } = DefaultHost;
+
+    [CommandOption("apikey", Description = "The API key to use with Meadow.Cloud. Otherwise, use the logged in Wilderness Labs account.", EnvironmentVariable = "MC_APIKEY", IsRequired = false)]
+    public string? ApiKey { get; set; }
 
     protected const string DefaultHost = Meadow.Cloud.Client.MeadowCloudClient.DefaultHost;
 
@@ -37,15 +41,22 @@ public abstract class BaseCloudCommand<T> : BaseCommand<T>
 
         if (RequiresAuthentication)
         {
-            var result = await MeadowCloudClient.Authenticate(CancellationToken);
-            if (!result)
+            if (!string.IsNullOrEmpty(ApiKey))
             {
-                throw new CommandException("You must be signed into your Wilderness Labs account to execute this command. Run 'meadow login' to do so.");
+                MeadowCloudClient.Authorization = new AuthenticationHeaderValue("APIKEY", ApiKey);
             }
+            else
+            {
+                var result = await MeadowCloudClient.Authenticate(CancellationToken);
+                if (!result)
+                {
+                    throw new CommandException("You must be signed into your Wilderness Labs account to execute this command. Run 'meadow login' to do so.");
+                }
 
-            // If the user does not yet exist in Meadow.Cloud, this creates them and sets up their initial org
-            var _ = await MeadowCloudClient.User.GetUser(CancellationToken)
-                ?? throw new CommandException("There was a problem retrieving your account information.");
+                // If the user does not yet exist in Meadow.Cloud, this creates them and sets up their initial org
+                var _ = await MeadowCloudClient.User.GetUser(CancellationToken)
+                    ?? throw new CommandException("There was a problem retrieving your account information.");
+            }
         }
 
         try
@@ -55,6 +66,21 @@ public abstract class BaseCloudCommand<T> : BaseCommand<T>
         catch (MeadowCloudAuthException ex)
         {
             throw new CommandException("You must be signed into your Wilderness Labs account to execute this command. Run 'meadow login' to do so.", ex);
+        }
+        catch (MeadowCloudException ex)
+        {
+            if (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            {
+                throw new CommandException($"You are not authorized to perform this action. Please check that you have appropriate access"
+                    + (!string.IsNullOrWhiteSpace(ApiKey) ? ", your API key has the correct scope(s)," : "") + " and try again.", ex);
+            }
+
+            throw new CommandException($@"There was a problem executing the command. Meadow.Cloud returned a non-successful response.
+
+{(int)ex.StatusCode} {ex.StatusCode}
+Response: {(string.IsNullOrWhiteSpace(ex.Response) ? "None" : Environment.NewLine + ex.Response)}
+
+{ex.StackTrace}", ex);
         }
     }
 

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
@@ -45,7 +45,7 @@ public abstract class BaseCloudCommand<T> : BaseCommand<T>
 
         if (!Uri.TryCreate(Host, UriKind.Absolute, out Uri? baseAddress) || baseAddress == null)
         {
-            throw new CommandException("Host (--host) must be a valid URL.", showHelp: true);
+            throw new CommandException("Host (--host) must be a valid URL.");
         }
         
         MeadowCloudClient.BaseAddress = baseAddress;

--- a/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/BaseCloudCommand.cs
@@ -38,6 +38,18 @@ public abstract class BaseCloudCommand<T> : BaseCommand<T>
 
     protected sealed override async ValueTask ExecuteCommand()
     {
+        if (!Host.StartsWith("http://", StringComparison.OrdinalIgnoreCase) && !Host.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new CommandException("Host (--host) must be a valid URL that starts with http:// or https://.");
+        }
+
+        if (!Uri.TryCreate(Host, UriKind.Absolute, out Uri? baseAddress) || baseAddress == null)
+        {
+            throw new CommandException("Host (--host) must be a valid URL.", showHelp: true);
+        }
+        
+        MeadowCloudClient.BaseAddress = baseAddress;
+
         await PreAuthenticatedValidation();
 
         if (RequiresAuthentication)

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyCreateCommand.cs
@@ -40,18 +40,11 @@ public class CloudApiKeyCreateCommand : BaseCloudCommand<CloudApiKeyCreateComman
 
     protected async override ValueTask ExecuteCloudCommand()
     {
-        try
-        {
-            var request = new CreateApiTokenRequest(Name, Duration, Scopes);
-            var response = await ApiTokenService.CreateApiToken(request, Host, CancellationToken);
+        var request = new CreateApiTokenRequest(Name, Duration, Scopes);
+        var response = await ApiTokenService.CreateApiToken(request, Host, CancellationToken);
 
-            Logger.LogInformation($"Your API key '{response.Name}' (expiring {response.ExpiresAt:G} UTC) is:");
-            Logger.LogInformation($"\n{response.Token}\n");
-            Logger.LogInformation("Make sure to copy this key now as you will not be able to see this again.");
-        }
-        catch (MeadowCloudException ex)
-        {
-            throw new CommandException($"Create API key command failed: {ex.Message}", innerException: ex);
-        }
+        Logger.LogInformation($"Your API key '{response.Name}' (expiring {response.ExpiresAt:G} UTC) is:");
+        Logger.LogInformation($"\n{response.Token}\n");
+        Logger.LogInformation("Make sure to copy this key now as you will not be able to see this again.");
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyDeleteCommand.cs
@@ -29,21 +29,14 @@ public class CloudApiKeyDeleteCommand : BaseCloudCommand<CloudApiKeyDeleteComman
 
     protected async override ValueTask ExecuteCloudCommand()
     {
-        try
-        {
-            var getRequest = await ApiTokenService.GetApiTokens(Host, CancellationToken);
-            var apiKey = getRequest.FirstOrDefault(x => x.Id == NameOrId || string.Equals(x.Name, NameOrId, StringComparison.OrdinalIgnoreCase));
+        var getRequest = await ApiTokenService.GetApiTokens(Host, CancellationToken);
+        var apiKey = getRequest.FirstOrDefault(x => x.Id == NameOrId || string.Equals(x.Name, NameOrId, StringComparison.OrdinalIgnoreCase));
 
-            if (apiKey == null)
-            {
-                throw new CommandException($"API key `{NameOrId}` not found.");
-            }
-
-            await ApiTokenService.DeleteApiToken(apiKey.Id, Host, CancellationToken);
-        }
-        catch (MeadowCloudException ex)
+        if (apiKey == null)
         {
-            throw new CommandException($"Create API key command failed: {ex.Message}", innerException: ex);
+            throw new CommandException($"API key `{NameOrId}` not found.");
         }
+
+        await ApiTokenService.DeleteApiToken(apiKey.Id, Host, CancellationToken);
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyListCommand.cs
@@ -26,29 +26,22 @@ public class CloudApiKeyListCommand : BaseCloudCommand<CloudApiKeyListCommand>
 
     protected override async ValueTask ExecuteCloudCommand()
     {
-        try
+        var response = await ApiTokenService.GetApiTokens(Host, CancellationToken);
+        var apiTokens = response.OrderBy(a => a.Name);
+
+        if (!apiTokens.Any())
         {
-            var response = await ApiTokenService.GetApiTokens(Host, CancellationToken);
-            var apiTokens = response.OrderBy(a => a.Name);
-
-            if (!apiTokens.Any())
-            {
-                Logger.LogInformation("You have no API keys.");
-                return;
-            }
-
-            var table = new ConsoleTable("Id", "Name", $"Expires (UTC)", "Scopes");
-            foreach (var apiToken in apiTokens)
-            {
-                table.AddRow(apiToken.Id, apiToken.Name, $"{apiToken.ExpiresAt:G}", string.Join(", ", apiToken.Scopes.OrderBy(t => t)));
-            }
-
-            Logger.LogInformation(table);
+            Logger.LogInformation("You have no API keys.");
+            return;
         }
-        catch (MeadowCloudException ex)
+
+        var table = new ConsoleTable("Id", "Name", $"Expires (UTC)", "Scopes");
+        foreach (var apiToken in apiTokens)
         {
-            throw new CommandException($"Get API keys command failed: {ex.Message}", innerException: ex);
+            table.AddRow(apiToken.Id, apiToken.Name, $"{apiToken.ExpiresAt:G}", string.Join(", ", apiToken.Scopes.OrderBy(t => t)));
         }
+
+        Logger.LogInformation(table);
     }
 }
 

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/ApiKey/CloudApiKeyUpdateCommand.cs
@@ -35,25 +35,18 @@ public class CloudApiKeyUpdateCommand : BaseCloudCommand<CloudApiKeyUpdateComman
 
     protected async override ValueTask ExecuteCloudCommand()
     {
-        try
+        var getRequest = await ApiTokenService.GetApiTokens(Host, CancellationToken);
+        var apiKey = getRequest.FirstOrDefault(x => x.Id == NameOrId || string.Equals(x.Name, NameOrId, StringComparison.OrdinalIgnoreCase));
+
+        if (apiKey == null)
         {
-            var getRequest = await ApiTokenService.GetApiTokens(Host, CancellationToken);
-            var apiKey = getRequest.FirstOrDefault(x => x.Id == NameOrId || string.Equals(x.Name, NameOrId, StringComparison.OrdinalIgnoreCase));
-
-            if (apiKey == null)
-            {
-                throw new CommandException($"API key `{NameOrId}` not found.");
-            }
-
-            NewName ??= apiKey.Name;
-            Scopes ??= apiKey.Scopes;
-
-            var updateRequest = new UpdateApiTokenRequest(NewName!, Scopes!);
-            await ApiTokenService.UpdateApiToken(apiKey.Id, updateRequest, Host, CancellationToken);
+            throw new CommandException($"API key `{NameOrId}` not found.");
         }
-        catch (MeadowCloudException ex)
-        {
-            throw new CommandException($"Create API key command failed: {ex.Message}", innerException: ex);
-        }
+
+        NewName ??= apiKey.Name;
+        Scopes ??= apiKey.Scopes;
+
+        var updateRequest = new UpdateApiTokenRequest(NewName!, Scopes!);
+        await ApiTokenService.UpdateApiToken(apiKey.Id, updateRequest, Host, CancellationToken);
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Command/CloudCommandPublishCommand.cs
@@ -51,25 +51,18 @@ public class CloudCommandPublishCommand : BaseCloudCommand<CloudCommandPublishCo
 
     protected override async ValueTask ExecuteCloudCommand()
     {
-        try
+        if (!string.IsNullOrWhiteSpace(CollectionId))
         {
-            if (!string.IsNullOrWhiteSpace(CollectionId))
-            {
-                await CommandService.PublishCommandForCollection(CollectionId, CommandName, Arguments, (int)QualityOfService, Host, CancellationToken);
-            }
-            else if (DeviceIds?.Length > 0)
-            {
-                await CommandService.PublishCommandForDevices(DeviceIds, CommandName, Arguments, (int)QualityOfService, Host, CancellationToken);
-            }
-            else
-            {
-                throw new CommandException("Cannot specify both a collection ID (-c|--collectionId) and list of device IDs (-d|--deviceIds). Only one is allowed.");
-            }
-            Logger.LogInformation("Publish command successful.");
+            await CommandService.PublishCommandForCollection(CollectionId, CommandName, Arguments, (int)QualityOfService, Host, CancellationToken);
         }
-        catch (MeadowCloudException ex)
+        else if (DeviceIds?.Length > 0)
         {
-            throw new CommandException($"Publish command failed: {ex.Message}", innerException: ex);
+            await CommandService.PublishCommandForDevices(DeviceIds, CommandName, Arguments, (int)QualityOfService, Host, CancellationToken);
         }
+        else
+        {
+            throw new CommandException("Cannot specify both a collection ID (-c|--collectionId) and list of device IDs (-d|--deviceIds). Only one is allowed.");
+        }
+        Logger.LogInformation("Publish command successful.");
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackagePublishCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackagePublishCommand.cs
@@ -29,16 +29,9 @@ public class CloudPackagePublishCommand : BaseCloudCommand<CloudPackagePublishCo
 
     protected override async ValueTask ExecuteCloudCommand()
     {
-        try
-        {
-            Logger.LogInformation($"Publishing package {PackageId} to collection {CollectionId}...");
+        Logger.LogInformation($"Publishing package {PackageId} to collection {CollectionId}...");
 
-            await _packageService.PublishPackage(PackageId, CollectionId, Metadata ?? string.Empty, Host, CancellationToken);
-            Logger.LogInformation("Publish successful.");
-        }
-        catch (MeadowCloudException mex)
-        {
-            Logger.LogError($"Publish failed: {mex.Message}");
-        }
+        await _packageService.PublishPackage(PackageId, CollectionId, Metadata ?? string.Empty, Host, CancellationToken);
+        Logger.LogInformation("Publish successful.");
     }
 }

--- a/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageUploadCommand.cs
+++ b/Source/v2/Meadow.Cli/Commands/Current/Cloud/Package/CloudPackageUploadCommand.cs
@@ -42,16 +42,9 @@ public class CloudPackageUploadCommand : BaseCloudCommand<CloudPackageUploadComm
 
         if (org == null) { return; }
 
-        try
-        {
-            Logger.LogInformation($"Uploading package {Path.GetFileName(MpakPath)}...");
+        Logger.LogInformation($"Uploading package {Path.GetFileName(MpakPath)}...");
 
-            var package = await _packageService.UploadPackage(MpakPath, org.Id, Description ?? string.Empty, Host, CancellationToken);
-            Logger.LogInformation($"Upload complete. Package Id: {package.Id}");
-        }
-        catch (MeadowCloudException mex)
-        {
-            Logger.LogError($"Upload failed: {mex.Message}");
-        }
+        var package = await _packageService.UploadPackage(MpakPath, org.Id, Description ?? string.Empty, Host, CancellationToken);
+        Logger.LogInformation($"Upload complete. Package Id: {package.Id}");
     }
 }

--- a/Source/v2/Meadow.Cloud.Client/Services/ApiTokenService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/ApiTokenService.cs
@@ -4,14 +4,14 @@ public class ApiTokenService : CloudServiceBase
 {
     private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
 
-    public ApiTokenService(IdentityManager identityManager) : base(identityManager)
+    public ApiTokenService(IMeadowCloudClient meadowCloudClient) : base(meadowCloudClient)
     {
     }
 
-    public async Task<IEnumerable<GetApiTokenResponse>> GetApiTokens(string host, CancellationToken? cancellationToken)
+    public async Task<IEnumerable<GetApiTokenResponse>> GetApiTokens(string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
-        var response = await httpClient.GetAsync($"{host}/api/auth/tokens", cancellationToken ?? CancellationToken.None);
+        var response = await httpClient.GetAsync($"{host}/api/auth/tokens", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -19,15 +19,15 @@ public class ApiTokenService : CloudServiceBase
             throw new MeadowCloudException(response.StatusCode, response: message);
         }
 
-        return await response.Content.ReadFromJsonAsync<IEnumerable<GetApiTokenResponse>>(JsonSerializerOptions, cancellationToken ?? CancellationToken.None)
+        return await response.Content.ReadFromJsonAsync<IEnumerable<GetApiTokenResponse>>(JsonSerializerOptions, cancellationToken)
             ?? Enumerable.Empty<GetApiTokenResponse>();
     }
 
-    public async Task<CreateApiTokenResponse> CreateApiToken(CreateApiTokenRequest request, string host, CancellationToken? cancellationToken)
+    public async Task<CreateApiTokenResponse> CreateApiToken(CreateApiTokenRequest request, string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
         var content = new StringContent(JsonSerializer.Serialize(request, JsonSerializerOptions), Encoding.UTF8, "application/json");
-        var response = await httpClient.PostAsync($"{host}/api/auth/tokens", content, cancellationToken ?? CancellationToken.None);
+        var response = await httpClient.PostAsync($"{host}/api/auth/tokens", content, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -35,15 +35,15 @@ public class ApiTokenService : CloudServiceBase
             throw new MeadowCloudException(response.StatusCode, response: message);
         }
 
-        var result = await response.Content.ReadFromJsonAsync<CreateApiTokenResponse>(JsonSerializerOptions, cancellationToken ?? CancellationToken.None);
+        var result = await response.Content.ReadFromJsonAsync<CreateApiTokenResponse>(JsonSerializerOptions, cancellationToken);
         return result!;
     }
 
-    public async Task<UpdateApiTokenResponse> UpdateApiToken(string id, UpdateApiTokenRequest request, string host, CancellationToken? cancellationToken)
+    public async Task<UpdateApiTokenResponse> UpdateApiToken(string id, UpdateApiTokenRequest request, string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
         var content = new StringContent(JsonSerializer.Serialize(request, JsonSerializerOptions), Encoding.UTF8, "application/json");
-        var response = await httpClient.PutAsync($"{host}/api/auth/tokens/{id}", content, cancellationToken ?? CancellationToken.None);
+        var response = await httpClient.PutAsync($"{host}/api/auth/tokens/{id}", content, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -51,14 +51,14 @@ public class ApiTokenService : CloudServiceBase
             throw new MeadowCloudException(response.StatusCode, response: message);
         }
 
-        var result = await response.Content.ReadFromJsonAsync<UpdateApiTokenResponse>(JsonSerializerOptions, cancellationToken ?? CancellationToken.None);
+        var result = await response.Content.ReadFromJsonAsync<UpdateApiTokenResponse>(JsonSerializerOptions, cancellationToken);
         return result!;
     }
 
-    public async Task DeleteApiToken(string id, string host, CancellationToken? cancellationToken)
+    public async Task DeleteApiToken(string id, string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
-        var response = await httpClient.DeleteAsync($"{host}/api/auth/tokens/{id}", cancellationToken ?? CancellationToken.None);
+        var response = await httpClient.DeleteAsync($"{host}/api/auth/tokens/{id}", cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/Source/v2/Meadow.Cloud.Client/Services/CollectionService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/CollectionService.cs
@@ -2,11 +2,11 @@
 
 public class CollectionService : CloudServiceBase
 {
-    public CollectionService(IdentityManager identityManager) : base(identityManager)
+    public CollectionService(IMeadowCloudClient meadowCloudClient) : base(meadowCloudClient)
     {
     }
 
-    public async Task<List<Collection>> GetOrgCollections(string orgId, string host, CancellationToken? cancellationToken)
+    public async Task<List<Collection>> GetOrgCollections(string orgId, string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
 

--- a/Source/v2/Meadow.Cloud.Client/Services/CommandService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/CommandService.cs
@@ -2,7 +2,7 @@
 
 public class CommandService : CloudServiceBase
 {
-    public CommandService(IdentityManager identityManager) : base(identityManager)
+    public CommandService(IMeadowCloudClient meadowCloudClient) : base(meadowCloudClient)
     {
     }
 
@@ -12,7 +12,7 @@ public class CommandService : CloudServiceBase
         JsonDocument? arguments = null,
         int qualityOfService = 0,
         string? host = null,
-        CancellationToken? cancellationToken = null)
+        CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
 
@@ -23,7 +23,7 @@ public class CommandService : CloudServiceBase
             qos = qualityOfService
         };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await httpClient.PostAsync($"{host}/api/collections/{collectionId}/commands", content, cancellationToken ?? CancellationToken.None);
+        var response = await httpClient.PostAsync($"{host}/api/collections/{collectionId}/commands", content, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -38,7 +38,7 @@ public class CommandService : CloudServiceBase
         JsonDocument? arguments = null,
         int qualityOfService = 0,
         string? host = null,
-        CancellationToken? cancellationToken = null)
+        CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
 
@@ -50,7 +50,7 @@ public class CommandService : CloudServiceBase
             qos = qualityOfService
         };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
-        var response = await httpClient.PostAsync($"{host}/api/devices/commands", content, cancellationToken ?? CancellationToken.None);
+        var response = await httpClient.PostAsync($"{host}/api/devices/commands", content, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/Source/v2/Meadow.Cloud.Client/Services/DeviceService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/DeviceService.cs
@@ -2,7 +2,7 @@
 
 public class DeviceService : CloudServiceBase
 {
-    public DeviceService(IdentityManager identityManager) : base(identityManager)
+    public DeviceService(IMeadowCloudClient meadowCloudClient) : base(meadowCloudClient)
     {
     }
 

--- a/Source/v2/Meadow.Cloud.Client/Services/PackageService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/PackageService.cs
@@ -7,7 +7,7 @@ public class PackageService : CloudServiceBase
 {
     private readonly string _info_json = "info.json";
 
-    public PackageService(IdentityManager identityManager) : base(identityManager)
+    public PackageService(IMeadowCloudClient meadowCloudClient) : base(meadowCloudClient)
     {
     }
 
@@ -16,7 +16,7 @@ public class PackageService : CloudServiceBase
         string orgId,
         string description,
         string host,
-        CancellationToken? cancellationToken = null)
+        CancellationToken cancellationToken = default)
     {
         if (!File.Exists(mpakPath))
         {
@@ -94,14 +94,14 @@ public class PackageService : CloudServiceBase
         string collectionId,
         string metadata,
         string host,
-        CancellationToken? cancellationToken = null)
+        CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
 
         var payload = new { metadata, collectionId };
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
         var response =
-            await httpClient.PostAsync($"{host}/api/packages/{packageId}/publish", content, cancellationToken ?? CancellationToken.None);
+            await httpClient.PostAsync($"{host}/api/packages/{packageId}/publish", content, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -110,7 +110,7 @@ public class PackageService : CloudServiceBase
         }
     }
 
-    public async Task<List<Package>> GetOrgPackages(string orgId, string host, CancellationToken? cancellationToken = null)
+    public async Task<List<Package>> GetOrgPackages(string orgId, string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
 

--- a/Source/v2/Meadow.Cloud.Client/Services/UserService.cs
+++ b/Source/v2/Meadow.Cloud.Client/Services/UserService.cs
@@ -2,15 +2,15 @@
 
 public class UserService : CloudServiceBase
 {
-    public UserService(IdentityManager identityManager) : base(identityManager)
+    public UserService(IMeadowCloudClient meadowCloudClient) : base(meadowCloudClient)
     {
     }
 
-    public async Task<List<UserOrg>> GetUserOrgs(string host, CancellationToken? cancellationToken = null)
+    public async Task<List<UserOrg>> GetUserOrgs(string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
 
-        var response = await httpClient.GetAsync($"{host}/api/users/me/orgs", cancellationToken ?? CancellationToken.None);
+        var response = await httpClient.GetAsync($"{host}/api/users/me/orgs", cancellationToken);
 
         if (response.IsSuccessStatusCode)
         {
@@ -23,7 +23,7 @@ public class UserService : CloudServiceBase
         }
     }
 
-    public async Task<User?> GetMe(string host, CancellationToken? cancellationToken = null)
+    public async Task<User?> GetMe(string host, CancellationToken cancellationToken = default)
     {
         var httpClient = await GetAuthenticatedHttpClient(cancellationToken);
 


### PR DESCRIPTION
This adds support for specifying an API key when executing a Meadow.Cloud-specific command.