### PR TITLE
Add telemetry support

### DIFF
--- a/Source/v2/.editorconfig
+++ b/Source/v2/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.csproj]
+indent_style = space
+indent_size = 2

--- a/Source/v2/Meadow.CLI/Commands/Current/TelemetryCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/TelemetryCommand.cs
@@ -1,0 +1,69 @@
+﻿using CliFx.Attributes;
+using CliFx.Extensibility;
+using Meadow.Telemetry;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+[Command("telemetry", Description = "Manage participation in telemetry sharing")]
+public class TelemetryCommand : BaseCommand<TelemetryCommand>
+{
+    public TelemetryCommand(
+        ILoggerFactory loggerFactory)
+        : base(loggerFactory)
+    {
+    }
+
+    protected override ValueTask ExecuteCommand()
+    {
+        throw new CommandException("Specify one of the telemetry commands", true);
+    }
+}
+
+[Command("telemetry enable", Description = "Enable and opt in to telemetry sharing")]
+public class TelemetryEnableCommand : BaseCommand<TelemetryCommand>
+{
+    private readonly ISettingsManager _settingsManager;
+
+    public TelemetryEnableCommand(
+        ISettingsManager settingsManager,
+        ILoggerFactory loggerFactory)
+        : base(loggerFactory)
+    {
+        _settingsManager = settingsManager;
+    }
+
+    protected override ValueTask ExecuteCommand()
+    {
+        _settingsManager.SaveSetting(MeadowTelemetry.TelemetryEnabledSettingName, "true");
+
+        return ValueTask.CompletedTask;
+    }
+}
+
+[Command("telemetry disable", Description = "Disable and opt out of telemetry sharing")]
+public class TelemetryDisableCommand : BaseCommand<TelemetryCommand>
+{
+    private readonly ISettingsManager _settingsManager;
+
+    public TelemetryDisableCommand(
+        ISettingsManager settingsManager,
+        ILoggerFactory loggerFactory)
+        : base(loggerFactory)
+    {
+        _settingsManager = settingsManager;
+    }
+
+    protected override ValueTask ExecuteCommand()
+    {
+        _settingsManager.SaveSetting(MeadowTelemetry.TelemetryEnabledSettingName, "false");
+        _settingsManager.DeleteSetting(MeadowTelemetry.MachineIdSettingName);
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Source/v2/Meadow.Cli/Meadow.CLI.csproj
+++ b/Source/v2/Meadow.Cli/Meadow.CLI.csproj
@@ -30,15 +30,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-  	<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-  	<PackageReference Include="Serilog" Version="3.0.1" />
-  	<PackageReference Include="CliFx" Version="*" />
-  	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-  	<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-  	<PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-  	<PackageReference Include="System.Management" Version="7.0.2" />
-  	<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-  	<PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="CliFx" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Management" Version="7.0.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/v2/Meadow.Cli/Program.cs
+++ b/Source/v2/Meadow.Cli/Program.cs
@@ -5,6 +5,7 @@ using Meadow.Cloud.Client;
 using Meadow.Cloud.Client.Identity;
 using Meadow.Package;
 using Meadow.Software;
+using Meadow.Telemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -92,6 +93,10 @@ public class Program
         {
             Console.WriteLine($"Operation failed: {ex.Message}");
             returnCode = 1;
+        }
+        finally
+        {
+            MeadowTelemetry.Current.Dispose();
         }
 
         return returnCode;

--- a/Source/v2/Meadow.Cli/Strings.cs
+++ b/Source/v2/Meadow.Cli/Strings.cs
@@ -1,4 +1,6 @@
-﻿namespace Meadow.CLI;
+﻿using Meadow.Telemetry;
+
+namespace Meadow.CLI;
 
 public static class Strings
 {
@@ -65,4 +67,19 @@ public static class Strings
     public const string NewMeadowDeviceNotFound = "New Meadow device not found";
     public const string NoFirmwarePackagesFound = "No firmware packages found, run 'meadow firmware download' to download the latest firmware";
     public const string NoDefaultFirmwarePackageSet = "No default firmware package set, run 'meadow firmware default' to set the default firmware";
+
+    public static class Telemetry
+    {
+        public const string ConsentMessage = @$"
+Let's improve the Meadow experience together
+--------------------------------------------
+To help improve the Meadow experience, we'd like to collect anonymous usage data. This data helps us understand how our tools are used, so we can make them better for everyone. This usage data is not tied to individuals and no personally identifiable information is collected.
+
+Our privacy policy is available at https://www.wildernesslabs.co/privacy-policy.
+
+You can change your mind at any time by running the ""[bold]meadow telemetry [[enable|disable]][/]"" command or by setting the [bold]{MeadowTelemetry.TelemetryEnvironmentVariable}[/] environment variable to '1' or '0' ('true' or 'false', respectively).
+";
+
+        public const string AskToParticipate = "Would you like to participate?";
+    }
 }

--- a/Source/v2/Meadow.Cloud.Client/Meadow.Cloud.Client.csproj
+++ b/Source/v2/Meadow.Cloud.Client/Meadow.Cloud.Client.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="CredentialManagement.Standard" Version="1.0.4" />
+    <PackageReference Include="CredentialManagement.Standard" Version="1.0.4" />
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
- </ItemGroup>
-	
+  </ItemGroup>
+
 </Project>

--- a/Source/v2/Meadow.Dfu/Meadow.Dfu.csproj
+++ b/Source/v2/Meadow.Dfu/Meadow.Dfu.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netstandard2.0</TargetFramework>
-	<Nullable>enable</Nullable>
-	<LangVersion>10</LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/v2/Meadow.Firmware/Meadow.Firmware.csproj
+++ b/Source/v2/Meadow.Firmware/Meadow.Firmware.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	<ImplicitUsings>enable</ImplicitUsings>
-	<Nullable>enable</Nullable>
-	<LangVersion>10</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Source/v2/Meadow.Hcom/Meadow.HCom.csproj
+++ b/Source/v2/Meadow.Hcom/Meadow.HCom.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-	<LangVersion>10</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/v2/Meadow.Linker/Meadow.Linker.csproj
+++ b/Source/v2/Meadow.Linker/Meadow.Linker.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netstandard2.0</TargetFramework>
-	<Nullable>enable</Nullable>
-	<LangVersion>10</LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,18 +12,18 @@
   </ItemGroup>
 
   <ItemGroup>
-      <None Update="lib\illink.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="lib\illink.runtimeconfig.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="lib\meadow_link.xml">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="lib\Mono.Cecil.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+    <None Update="lib\illink.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="lib\illink.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="lib\meadow_link.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="lib\Mono.Cecil.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/Source/v2/Meadow.Tooling.Core/Meadow.Tooling.Core.csproj
+++ b/Source/v2/Meadow.Tooling.Core/Meadow.Tooling.Core.csproj
@@ -2,15 +2,16 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
-	<Nullable>enable</Nullable>
-	<LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Glob" Version="1.1.9" />
-	<PackageReference Include="YamlDotNet" Version="13.7.1" />
+    <PackageReference Include="Glob" Version="1.1.9" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-	<PackageReference Include="System.Management" Version="7.0.2" />
+    <PackageReference Include="System.Management" Version="7.0.2" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/v2/Meadow.Tooling.Core/Settings/SettingsManager.cs
+++ b/Source/v2/Meadow.Tooling.Core/Settings/SettingsManager.cs
@@ -33,14 +33,23 @@ public class SettingsManager : ISettingsManager
     public string? GetSetting(string setting)
     {
         var settings = GetSettings();
-        if (settings.Public.TryGetValue(setting.ToString(), out var ret))
+        Dictionary<string, string> target;
+
+        if (setting.StartsWith(PrivatePrefix))
         {
-            return ret;
+            setting = setting.Substring(PrivatePrefix.Length);
+            target = settings.Private;
         }
-        else if (settings.Private.TryGetValue(setting.ToString(), out var pret))
+        else
         {
-            return pret;
+            target = settings.Public;
         }
+
+        if (target.TryGetValue(setting, out var value))
+        {
+            return value;
+        }
+
         return null;
     }
 
@@ -59,7 +68,7 @@ public class SettingsManager : ISettingsManager
             target = settings.Public;
         }
 
-        if (target.ContainsKey(setting.ToString()))
+        if (target.ContainsKey(setting))
         {
             target.Remove(setting);
 

--- a/Source/v2/Meadow.Tooling.Core/Telemetry/CIEnvironmentDetector.cs
+++ b/Source/v2/Meadow.Tooling.Core/Telemetry/CIEnvironmentDetector.cs
@@ -1,0 +1,79 @@
+﻿// This contains code from the .NET SDK project at
+// https://github.com/dotnet/sdk/blob/v8.0.203/src/Cli/dotnet/Telemetry/CIEnvironmentDetectorForTelemetry.cs.
+// 
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// It has been modified by Wilderness Labs and are licensed under the Apache License, Version 2.0.
+// You may obtain a copy of the License at https://github.com/WildernessLabs/Meadow.CLI/blob/main/LICENSE
+using System;
+using System.Linq;
+
+namespace Meadow.Telemetry;
+
+internal static class CIEnvironmentDetector
+{
+    // Systems that provide boolean values only, so we can simply parse and check for true
+    private static readonly string[] _booleanVariables = new string[] {
+            // Azure Pipelines - https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables#system-variables-devops-services
+            "TF_BUILD",
+            // GitHub Actions - https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+            "GITHUB_ACTIONS",
+            // AppVeyor - https://www.appveyor.com/docs/environment-variables/
+            "APPVEYOR",
+            // A general-use flag - Many of the major players support this: AzDo, GitHub, GitLab, AppVeyor, Travis CI, CircleCI.
+            // Given this, we could potentially remove all of these other options?
+            "CI",
+            // Travis CI - https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+            "TRAVIS",
+            // CircleCI - https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+            "CIRCLECI",
+        };
+
+    // Systems where every variable must be present and not-null before returning true
+    private static readonly string[][] _allNotNullVariables = new string[][] {
+            // AWS CodeBuild - https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+            new string[]{ "CODEBUILD_BUILD_ID", "AWS_REGION" },
+            // Jenkins - https://github.com/jenkinsci/jenkins/blob/master/core/src/main/resources/jenkins/model/CoreEnvironmentContributor/buildEnv.groovy
+            new string[]{ "BUILD_ID", "BUILD_URL" },
+            // Google Cloud Build - https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions
+            new string[]{ "BUILD_ID", "PROJECT_ID" }
+        };
+
+    // Systems where the variable must be present and not-null
+    private static readonly string[] _ifNonNullVariables = new string[] {
+            // TeamCity - https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
+            "TEAMCITY_VERSION",
+            // JetBrains Space - https://www.jetbrains.com/help/space/automation-environment-variables.html#general
+            "JB_SPACE_API_URL"
+        };
+
+    public static bool IsCIEnvironment()
+    {
+        foreach (var booleanVariable in _booleanVariables)
+        {
+            if (bool.TryParse(Environment.GetEnvironmentVariable(booleanVariable), out bool envVar) && envVar)
+            {
+                return true;
+            }
+        }
+
+        foreach (var variables in _allNotNullVariables)
+        {
+            if (variables.All((variable) => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable))))
+            {
+                return true;
+            }
+        }
+
+        foreach (var variable in _ifNonNullVariables)
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(variable)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Source/v2/Meadow.Tooling.Core/Telemetry/MeadowTelemetry.cs
+++ b/Source/v2/Meadow.Tooling.Core/Telemetry/MeadowTelemetry.cs
@@ -1,0 +1,197 @@
+﻿using Meadow.CLI;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Threading;
+
+namespace Meadow.Telemetry;
+
+public sealed class MeadowTelemetry : IDisposable
+{
+    private const string ConnectionString = "InstrumentationKey=1c5d5d93-e50e-47bc-b14e-23e32dc1bcac";
+    private static readonly Lazy<MeadowTelemetry> _current = new(() => new MeadowTelemetry(new SettingsManager()));
+
+    public const string TelemetryEnvironmentVariable = "MEADOW_TELEMETRY";
+    public const string MachineIdSettingName = "private.telemetry.machineid";
+    public const string TelemetryEnabledSettingName = "telemetry.enabled";
+
+    private readonly ISettingsManager _settingsManager;
+    private TelemetryConfiguration? _telemetryConfiguration;
+
+    public TelemetryClient? TelemetryClient { get; private set; }
+
+    public static MeadowTelemetry Current => _current.Value;
+
+    public MeadowTelemetry(ISettingsManager settingsManager)
+    {
+        _settingsManager = settingsManager ?? throw new ArgumentNullException(nameof(settingsManager));
+        Initialize();
+    }
+
+    private void Initialize()
+    {
+        if (TelemetryClient != null)
+        {
+            return;
+        }
+
+        _telemetryConfiguration = CreateTelemetryConfiguration();
+
+        if (_telemetryConfiguration == null)
+        {
+            return;
+        }
+
+        TelemetryClient = new TelemetryClient(_telemetryConfiguration);
+        ConfigureTelemetryContext(TelemetryClient.Context);
+    }
+
+    public void Dispose()
+    {
+        TelemetryClient?.FlushAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+        _telemetryConfiguration?.Dispose();
+
+        TelemetryClient = null;
+        _telemetryConfiguration = null;
+    }
+
+    public bool IsEnabled
+    {
+        get
+        {
+            if (CIEnvironmentDetector.IsCIEnvironment())
+            {
+                return false;
+            }
+
+            if (bool.TryParse(Environment.GetEnvironmentVariable(TelemetryEnvironmentVariable), out bool isEnabled))
+            {
+                return isEnabled;
+            }
+
+            if (bool.TryParse(_settingsManager.GetSetting(TelemetryEnabledSettingName), out isEnabled))
+            {
+                return isEnabled;
+            }
+
+            return false;
+        }
+    }
+
+    public bool ShouldAskForConsent
+    {
+        get
+        {
+            if (CIEnvironmentDetector.IsCIEnvironment())
+            {
+                return false;
+            }
+
+            var envVar = Environment.GetEnvironmentVariable(TelemetryEnvironmentVariable);
+            if (!string.IsNullOrWhiteSpace(envVar) && bool.TryParse(envVar, out _))
+            {
+                return false;
+            }
+
+            var setting = _settingsManager.GetSetting(TelemetryEnabledSettingName);
+            if (!string.IsNullOrWhiteSpace(setting) && bool.TryParse(setting, out _))
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    public void SetTelemetryEnabled(bool enabled)
+    {
+        _settingsManager.SaveSetting(TelemetryEnabledSettingName, enabled.ToString().ToLowerInvariant());
+
+        if (enabled)
+        {
+            Initialize();
+        }
+        else
+        {
+            Dispose();
+            _settingsManager.DeleteSetting(MachineIdSettingName);
+        }
+    }
+
+    public void TrackCommand(string? commandName)
+    {
+        if (TelemetryClient == null)
+        {
+            return;
+        }
+
+        var eventTelemetry = new EventTelemetry("meadow/cli/command")
+        {
+            Timestamp = DateTimeOffset.UtcNow
+        };
+
+        eventTelemetry.Properties["Command"] = commandName?.ToLowerInvariant() ?? "<unknown>";
+        TelemetryClient.TrackEvent(eventTelemetry);
+    }
+
+    private TelemetryConfiguration? CreateTelemetryConfiguration()
+    {
+        if (!IsEnabled)
+        {
+            return null;
+        }
+
+        var telemetryConfiguration = new TelemetryConfiguration
+        {
+            ConnectionString = ConnectionString
+        };
+
+#if DEBUG
+        telemetryConfiguration.TelemetryChannel.DeveloperMode = true;
+#endif
+
+        return telemetryConfiguration;
+    }
+
+    private void ConfigureTelemetryContext(TelemetryContext context)
+    {
+        context.Cloud.RoleInstance = "<undefined>";
+        context.Device.Type = "<undefined>";
+        context.Location.Ip = "0.0.0.0";
+        context.Session.Id = GetRandomString(24);
+        context.User.Id = GetMachineId();
+
+        context.GlobalProperties["OS Version"] = RuntimeEnvironment.OperatingSystemVersion;
+        context.GlobalProperties["OS Platform"] = RuntimeEnvironment.OperatingSystemPlatform.ToString();
+        context.GlobalProperties["OS Architecture"] = RuntimeInformation.OSArchitecture.ToString();
+        context.GlobalProperties["Kernel Version"] = RuntimeInformation.OSDescription;
+        context.GlobalProperties["Runtime Identifier"] = AppContext.GetData("RUNTIME_IDENTIFIER") as string ?? "<unknown>";
+        context.GlobalProperties["Assembly Name"] = Assembly.GetEntryAssembly()?.GetName().Name;
+        context.GlobalProperties["Assembly Version"] = Assembly.GetEntryAssembly()?.GetName().Version?.ToString(3);
+    }
+
+    private string GetMachineId()
+    {
+        var machineId = _settingsManager.GetSetting(MachineIdSettingName) ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(machineId))
+        {
+            machineId = Guid.NewGuid().ToString("N");
+            _settingsManager.SaveSetting(MachineIdSettingName, machineId);
+        }
+
+        return machineId;
+    }
+
+    private static string GetRandomString(int length)
+    {
+        using var rng = RandomNumberGenerator.Create();
+        byte[] bytes = new byte[length];
+        rng.GetBytes(bytes);
+
+        return Convert.ToBase64String(bytes);
+    }
+}

--- a/Source/v2/Meadow.Tooling.Core/Telemetry/RuntimeEnvironment.cs
+++ b/Source/v2/Meadow.Tooling.Core/Telemetry/RuntimeEnvironment.cs
@@ -1,0 +1,281 @@
+﻿// This contains code from the .NET SDK project at
+// https://github.com/dotnet/sdk/blob/v8.0.203/src/Cli/Microsoft.DotNet.Cli.Utils/RuntimeEnvironment.cs.
+// 
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+// It has been modified by Wilderness Labs and are licensed under the Apache License, Version 2.0.
+// You may obtain a copy of the License at https://github.com/WildernessLabs/Meadow.CLI/blob/main/LICENSE
+
+#nullable disable
+
+using System.Runtime.InteropServices;
+using System;
+using System.IO;
+
+namespace Meadow.Telemetry;
+
+internal enum Platform
+{
+    Unknown = 0,
+    Windows = 1,
+    Linux = 2,
+    Darwin = 3,
+    FreeBSD = 4,
+    illumos = 5,
+    Solaris = 6,
+    Haiku = 7
+}
+
+internal static class RuntimeEnvironment
+{
+    private static readonly Lazy<Platform> _platform = new(DetermineOSPlatform);
+    private static readonly Lazy<DistroInfo> _distroInfo = new(LoadDistroInfo);
+
+    public static Platform OperatingSystemPlatform { get; } = GetOSPlatform();
+    public static string OperatingSystemVersion { get; } = GetOSVersion();
+    public static string OperatingSystem { get; } = GetOSName();
+
+    private class DistroInfo
+    {
+        public string Id;
+        public string VersionId;
+    }
+
+    private static string GetOSName()
+    {
+        switch (GetOSPlatform())
+        {
+            case Platform.Windows:
+                return nameof(Platform.Windows);
+            case Platform.Linux:
+                return GetDistroId() ?? nameof(Platform.Linux);
+            case Platform.Darwin:
+                return "Mac OS X";
+            case Platform.FreeBSD:
+                return nameof(Platform.FreeBSD);
+            case Platform.illumos:
+                return GetDistroId() ?? nameof(Platform.illumos);
+            case Platform.Solaris:
+                return nameof(Platform.Solaris);
+            case Platform.Haiku:
+                return nameof(Platform.Haiku);
+            default:
+                return nameof(Platform.Unknown);
+        }
+    }
+
+    private static string GetOSVersion()
+    {
+        switch (GetOSPlatform())
+        {
+            case Platform.Windows:
+                return Environment.OSVersion.Version.ToString(3);
+            case Platform.Linux:
+            case Platform.illumos:
+                return GetDistroVersionId() ?? string.Empty;
+            case Platform.Darwin:
+                return Environment.OSVersion.Version.ToString(2);
+            case Platform.FreeBSD:
+                return GetFreeBSDVersion() ?? string.Empty;
+            case Platform.Solaris:
+                // RuntimeInformation.OSDescription example on Solaris 11.3:      SunOS 5.11 11.3
+                // we only need the major version; 11
+                return RuntimeInformation.OSDescription.Split(' ')[2].Split('.')[0];
+            case Platform.Haiku:
+                return Environment.OSVersion.Version.ToString(1);
+            default:
+                return string.Empty;
+        }
+    }
+
+    private static string GetFreeBSDVersion()
+    {
+        // This is same as sysctl kern.version
+        // FreeBSD 11.0-RELEASE-p1 FreeBSD 11.0-RELEASE-p1 #0 r306420: Thu Sep 29 01:43:23 UTC 2016     root@releng2.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC
+        // What we want is major release as minor releases should be compatible.
+        string version = RuntimeInformation.OSDescription;
+        try
+        {
+            // second token up to first dot
+            return RuntimeInformation.OSDescription.Split()[1].Split('.')[0];
+        }
+        catch
+        {
+        }
+        return string.Empty;
+    }
+
+    private static Platform GetOSPlatform()
+    {
+        return _platform.Value;
+    }
+
+    private static string GetDistroId()
+    {
+        return _distroInfo.Value?.Id;
+    }
+
+    private static string GetDistroVersionId()
+    {
+        return _distroInfo.Value?.VersionId;
+    }
+
+    private static DistroInfo LoadDistroInfo()
+    {
+        switch (GetOSPlatform())
+        {
+            case Platform.Linux:
+                return LoadDistroInfoFromLinux();
+            case Platform.illumos:
+                return LoadDistroInfoFromIllumos();
+        }
+
+        return null;
+    }
+
+    private static DistroInfo LoadDistroInfoFromLinux()
+    {
+        DistroInfo result = null;
+
+        // Sample os-release file:
+        //   NAME="Ubuntu"
+        //   VERSION = "14.04.3 LTS, Trusty Tahr"
+        //   ID = ubuntu
+        //   ID_LIKE = debian
+        //   PRETTY_NAME = "Ubuntu 14.04.3 LTS"
+        //   VERSION_ID = "14.04"
+        //   HOME_URL = "http://www.ubuntu.com/"
+        //   SUPPORT_URL = "http://help.ubuntu.com/"
+        //   BUG_REPORT_URL = "http://bugs.launchpad.net/ubuntu/"
+        // We use ID and VERSION_ID
+
+        if (File.Exists("/etc/os-release"))
+        {
+            var lines = File.ReadAllLines("/etc/os-release");
+            result = new DistroInfo();
+            foreach (var line in lines)
+            {
+                if (line.StartsWith("ID=", StringComparison.Ordinal))
+                {
+                    result.Id = line.Substring(3).Trim('"', '\'');
+                }
+                else if (line.StartsWith("VERSION_ID=", StringComparison.Ordinal))
+                {
+                    result.VersionId = line.Substring(11).Trim('"', '\'');
+                }
+            }
+        }
+
+        if (result != null)
+        {
+            result = NormalizeDistroInfo(result);
+        }
+
+        return result;
+    }
+
+    private static DistroInfo LoadDistroInfoFromIllumos()
+    {
+        DistroInfo result = null;
+        // examples:
+        //   on OmniOS
+        //       SunOS 5.11 omnios-r151018-95eaa7e
+        //   on OpenIndiana Hipster:
+        //       SunOS 5.11 illumos-63878f749f
+        //   on SmartOS:
+        //       SunOS 5.11 joyent_20200408T231825Z
+        var versionDescription = RuntimeInformation.OSDescription.Split(' ')[2];
+        switch (versionDescription)
+        {
+            case string version when version.StartsWith("omnios"):
+                result = new DistroInfo
+                {
+                    Id = "OmniOS",
+                    VersionId = version.Substring("omnios-r".Length, 2) // e.g. 15
+                };
+                break;
+            case string version when version.StartsWith("joyent"):
+                result = new DistroInfo
+                {
+                    Id = "SmartOS",
+                    VersionId = version.Substring("joyent_".Length, 4) // e.g. 2020
+                };
+                break;
+            case string version when version.StartsWith("illumos"):
+                result = new DistroInfo
+                {
+                    Id = "OpenIndiana"
+                    // version-less
+                };
+                break;
+        }
+
+        return result;
+    }
+
+    // For some distros, we don't want to use the full version from VERSION_ID. One example is
+    // Red Hat Enterprise Linux, which includes a minor version in their VERSION_ID but minor
+    // versions are backwards compatable.
+    //
+    // In this case, we'll normalized RIDs like 'rhel.7.2' and 'rhel.7.3' to a generic
+    // 'rhel.7'. This brings RHEL in line with other distros like CentOS or Debian which
+    // don't put minor version numbers in their VERSION_ID fields because all minor versions
+    // are backwards compatible.
+    private static DistroInfo NormalizeDistroInfo(DistroInfo distroInfo)
+    {
+        // Handle if VersionId is null by just setting the index to -1.
+        int lastVersionNumberSeparatorIndex = distroInfo.VersionId?.IndexOf('.') ?? -1;
+
+        if (lastVersionNumberSeparatorIndex != -1 && distroInfo.Id == "alpine")
+        {
+            // For Alpine, the version reported has three components, so we need to find the second version separator
+            lastVersionNumberSeparatorIndex = distroInfo.VersionId.IndexOf('.', lastVersionNumberSeparatorIndex + 1);
+        }
+
+        if (lastVersionNumberSeparatorIndex != -1 && (distroInfo.Id == "rhel" || distroInfo.Id == "alpine"))
+        {
+            distroInfo.VersionId = distroInfo.VersionId.Substring(0, lastVersionNumberSeparatorIndex);
+        }
+
+        return distroInfo;
+    }
+
+    private static Platform DetermineOSPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return Platform.Windows;
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return Platform.Linux;
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return Platform.Darwin;
+        }
+#if NETCOREAPP
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+        {
+            return Platform.FreeBSD;
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("ILLUMOS")))
+        {
+            return Platform.illumos;
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("SOLARIS")))
+        {
+            return Platform.Solaris;
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("HAIKU")))
+        {
+            return Platform.Haiku;
+        }
+#endif
+
+        return Platform.Unknown;
+    }
+}
+
+#nullable enable

--- a/Source/v2/Meadow.UsbLib.Core/Meadow.UsbLib.Core.csproj
+++ b/Source/v2/Meadow.UsbLib.Core/Meadow.UsbLib.Core.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>netstandard2.0</TargetFramework>
-      <LangVersion>10</LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Source/v2/Meadow.UsbLib/Meadow.UsbLib.csproj
+++ b/Source/v2/Meadow.UsbLib/Meadow.UsbLib.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-      <LangVersion>10</LangVersion>
-      <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="LibUsbDotNet" Version="3.0.102-alpha" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="LibUsbDotNet" Version="3.0.102-alpha" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Meadow.UsbLib.Core\Meadow.UsbLib.Core.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Meadow.UsbLib.Core\Meadow.UsbLib.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/v2/Meadow.UsbLibClassic/Meadow.UsbLibClassic.csproj
+++ b/Source/v2/Meadow.UsbLibClassic/Meadow.UsbLibClassic.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>netstandard2.0</TargetFramework>
-      <LangVersion>10</LangVersion>
-      <Nullable>enable</Nullable>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="LibUsbDotNet" Version="2.2.29" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Meadow.UsbLib.Core\Meadow.UsbLib.Core.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Meadow.UsbLib.Core\Meadow.UsbLib.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/Meadow.Cloud.Client.Unit.Tests.csproj
+++ b/Source/v2/Tests/Meadow.Cloud.Client.Unit.Tests/Meadow.Cloud.Client.Unit.Tests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy.Extensions.ValueTask" Version="8.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-      <ProjectReference Include="..\..\Meadow.Cloud.Client\Meadow.Cloud.Client.csproj" />
+    <ProjectReference Include="..\..\Meadow.Cloud.Client\Meadow.Cloud.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Source/v2/Tests/Meadow.SoftwareManager.Integration.Tests/Meadow.SoftwareManager.Integration.Tests.csproj
+++ b/Source/v2/Tests/Meadow.SoftwareManager.Integration.Tests/Meadow.SoftwareManager.Integration.Tests.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-      <ProjectReference Include="..\..\Meadow.Cloud.Client\Meadow.Cloud.Client.csproj" />
-      <ProjectReference Include="..\..\Meadow.SoftwareManager\Meadow.SoftwareManager.csproj" />
+    <ProjectReference Include="..\..\Meadow.Cloud.Client\Meadow.Cloud.Client.csproj" />
+    <ProjectReference Include="..\..\Meadow.SoftwareManager\Meadow.SoftwareManager.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This adds support for collecting anonymous usage data to help understand how the CLI is used and how to help improve the Meadow CLI, Workbench, and IDE extensions.

## How to opt in

The Meadow CLI displays a message similar to the one below when you first run a Meadow CLI command and have not yet decided to participate or not.

```
Let's improve the Meadow experience together
--------------------------------------------
To help improve the Meadow CLI, we'd like to collect anonymous usage data. This data helps
us understand how the CLI is used, so we can make it better for everyone. This usage data
not tied to individuals and no personally identifiable information is collected.

Our privacy policy is available at https://www.wildernesslabs.co/privacy-policy.

You can change your mind at any time by running the "meadow telemetry [enable|disable]"
command or by setting the MEADOW_TELEMETRY environment variable to '1' or '0' ('true' or
'false', respectively).

Would you like to participate? [y/n] (y):
```

Once a user has given their choice, that choice is saved to the Meadow CLI configuration (that can be viewed with `meadow config --list`) and this message will no longer appear.

This can be overridden entirely by setting the `MEADOW_TELEMETRY` environment variable to `1`/`true` to opt-in or `0`/`false` (to opt-out). If that environment variable is set, then this message will not be displayed.

A best effort is made to determine if the Meadow CLI command is being run in a continuous integration (CI) environment. If it is, then telemetry is **opt-out and disabled by default**.

## Data points

The usage collection is for anonymous usage data only. It doesn't collect personal data such as username or email address, nor anything about the command being run outside of the command/subcommand name (no command arguments are collected).

This feature collects the following information:

_The examples are based on a running the command `meadow cloud command publish my_command --collectionId 12345`._

| Data | Example | Notes |
|-|-|-|
| Command | `cloud command publish` | |
| SessionId | `hDtIQEoBKMbicpggF4r+wIB61Fjw68aP` | This is a random string generated at runtime and used only while the command is executed. |
| MachineId | `bb4d522020164e4cadec605c4b0521d4` | This is a random Guid that is generated at runtime once and stored in the Meadow CLI config. If this value is found in the config, that value is used. |
| Assembly Name | `meadow` | |
| Assembly Version| `2.0.33` | |
| OS Version | `10.0.22631` | |
| OS Platform | `Windows` | |
| OS Architecture | `X64` | |
| Kernel Version | `Microsoft Windows 10.0.22631` | |
| Runtime Identifier | `win-x64` | |
