### PR TITLE
Fix trim hanging and incorrect status results.

### DIFF
--- a/Source/v2/Meadow.Linker/Linker/MeadowLinker.cs
+++ b/Source/v2/Meadow.Linker/Linker/MeadowLinker.cs
@@ -109,6 +109,7 @@ public class MeadowLinker
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Error trimming Meadow app");
+            throw;
         }
 
         return Directory.EnumerateFiles(postlink_dir);


### PR DESCRIPTION
On some systems where the ILLinker fails to trim, the CLI trim command was hanging.

This was caused because stderror was redirected but we never began reading from it.  We can't just `ReadToEndAsync()` on stderror because then we get a hang because of stdout.  So in order to work around this, use the `OutputDataReceived` and `ErrorDataReceived` functions to reading, and used `BeginErrorReadLine()` and `BeginOutputReadLine()` to execute reading of the buffers.

While this fixed the hang, it immediately claimed that trimming was successful even though the process failed with a non-zero exit code. There were two reasons for this:

1. Any exception in `ILLinker.RunILLink()` gets read by `MeadowLinker.TrimMeadowApp()`'s catch statement and then disregarded, and no error code or anything else bubbles up
2. The `_logger?.LogError()` call doesn't execute because `_logger` is null, thus no output is ever seen (anywhere in the app really).

So to fix these two issues I made `MeadowLinker.TrimMeadowApp()` bubble up the exception.  This not only allows us to exit the cli for the IL Link failure (and not consider it a success), but it also shows the user ILLink output so they can diagnose the failure.