### PR TITLE
Add meadow update command.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -88,7 +88,7 @@ jobs:
       run: dotnet build main/MeadowCLI.Classic.sln /p:Configuration=Release
 
     - name: Upload nuget Artifacts for internal testing
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Meadow.CLI.Classic.nuget.${{ ENV.CLI_RELEASE_VERSION_1 }}
         path: 'main\Meadow.CLI.Classic\bin\Release\*.nupkg'
@@ -100,7 +100,7 @@ jobs:
       run: dotnet build main/MeadowCLI.sln /p:Configuration=Release
 
     - name: Upload nuget Artifacts for internal testing
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Meadow.CLI.nuget.${{ ENV.CLI_RELEASE_VERSION_1 }}
         path: 'main\Meadow.CLI\bin\Release\*.nupkg'
@@ -117,7 +117,7 @@ jobs:
       run: dotnet build main/Source/v2/Meadow.CLI.v2.sln /p:Configuration=Release
 
     - name: Upload nuget Artifacts for internal testing
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Meadow.CLI.nuget.${{ ENV.CLI_RELEASE_VERSION_2 }}
         path: 'main\Source\v2\Meadow.CLI\bin\Release\*.nupkg'
@@ -185,7 +185,7 @@ jobs:
   #       DevEnvDir: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE'
 
   #   - name: Upload VS2019 VSIX Artifacts
-  #     uses: actions/upload-artifact@v2
+  #     uses: actions/upload-artifact@v4
   #     with:
   #       name: Meadow.Win.VS2019.vsix.${{ ENV.IDE_TOOLS_RELEASE_VERSION }}
   #       path: 'vs-win\VS_Meadow_Extension\VS_Meadow_Extension.2019\bin\Release\*.vsix'
@@ -326,7 +326,7 @@ jobs:
   #       msbuild vs-mac/VS4Mac_Meadow_Extension.sln /t:Build /p:Configuration=Release /p:CreatePackage=true
 
   #   - name: Upload Mac VS2019 mpack Artifacts
-  #     uses: actions/upload-artifact@v2
+  #     uses: actions/upload-artifact@v4
   #     with:
   #       name: Meadow.Mac.2019.mpack.${{ ENV.IDE_TOOLS_RELEASE_VERSION }}
   #       path: 'vs-mac/VS4Mac_Meadow_Extension/bin/Release/net472/*.mpack'
@@ -435,7 +435,7 @@ jobs:
         dotnet msbuild vs-mac/VS4Mac_Meadow_Extension/Meadow.Sdks.IdeExtensions.Vs4Mac.2022.csproj /t:Build /p:Configuration=Release /p:CreatePackage=true
     
     - name: Upload VS2022 mpack Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Meadow.Mac.2022.mpack.${{ ENV.IDE_TOOLS_RELEASE_VERSION }}
         path: 'vs-mac/VS4Mac_Meadow_Extension/bin/Release/net7.0/*.mpack'
@@ -584,7 +584,7 @@ jobs:
         vsce package
 
     - name: Upload VSIX Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Meadow.VSCode.vsix.${{ ENV.IDE_TOOLS_RELEASE_VERSION }}
         path: 'vs-code/*.vsix'

--- a/Source/v2/Meadow.CLI.v2.sln
+++ b/Source/v2/Meadow.CLI.v2.sln
@@ -40,7 +40,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Meadow.Dfu", "Meadow.Dfu\Me
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Meadow.Firmware", "Meadow.Firmware\Meadow.Firmware.csproj", "{D2274F30-A001-482A-99E3-0AB1970CF695}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Meadow.Tooling.Core", "Meadow.Tooling.Core\Meadow.Tooling.Core.csproj", "{A22DBF4A-E472-445E-96C0-930C126039C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Meadow.Tooling.Core", "Meadow.Tooling.Core\Meadow.Tooling.Core.csproj", "{A22DBF4A-E472-445E-96C0-930C126039C2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Meadow.Updater", "Meadow.Updater\Meadow.Updater.csproj", "{78D924D6-9D20-46DE-A178-D3AA830B9A55}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -124,6 +126,10 @@ Global
 		{A22DBF4A-E472-445E-96C0-930C126039C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A22DBF4A-E472-445E-96C0-930C126039C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A22DBF4A-E472-445E-96C0-930C126039C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78D924D6-9D20-46DE-A178-D3AA830B9A55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78D924D6-9D20-46DE-A178-D3AA830B9A55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78D924D6-9D20-46DE-A178-D3AA830B9A55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78D924D6-9D20-46DE-A178-D3AA830B9A55}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/v2/Meadow.CLI/Commands/Current/UpdateCommand.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/UpdateCommand.cs
@@ -1,0 +1,84 @@
+﻿using System.Reflection;
+using CliFx.Attributes;
+using Microsoft.Extensions.Logging;
+
+namespace Meadow.CLI.Commands.DeviceManagement;
+
+[Command("update", Description = Strings.Update.Description)]
+public class UpdateCommand : BaseCommand<UpdateCommand>
+{
+	const string MEADOW_CLI = "WildernessLabs.Meadow.CLI";
+	const string MEADOW_UPDATER = "Meadow.Updater";
+	const string CLIFX = "CliFx";
+
+	[CommandOption("version", 'v', IsRequired = false)]
+	public string? Version { get; set; }
+
+	public UpdateCommand(ILoggerFactory loggerFactory)
+		: base(loggerFactory)
+	{
+	}
+
+	protected override async ValueTask ExecuteCommand()
+	{
+		Logger.LogInformation(Strings.Update.Updating, MEADOW_CLI);
+
+		string toVersion;
+		if (!string.IsNullOrWhiteSpace(Version))
+		{
+			toVersion = $"v{Version}";
+		}
+		else
+		{
+			toVersion = "vLatest";
+		}
+		 ;
+		Logger.LogInformation(Strings.Update.Instruction1, MEADOW_CLI, toVersion);
+		Logger.LogInformation(Strings.Update.Instruction2);
+
+		// Path to the updater executable within the tool's output directory
+		string meadowUpdaterPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, $"{MEADOW_UPDATER}.dll");
+
+		// Ensure the updater executable exists
+		if (!File.Exists(meadowUpdaterPath))
+		{
+			Logger.LogError(Strings.Update.UpdaterNotFound);
+			return;
+		}
+
+		// Copy all necessary files to a temporary location, so there aren't any access issues
+		string tempUpdaterDir = Path.Combine(Path.GetTempPath(), MEADOW_UPDATER);
+		if (!Directory.Exists(tempUpdaterDir))
+		{
+			Directory.CreateDirectory(tempUpdaterDir);
+		}
+		CopyMeadowUpdaterFiles(Path.GetDirectoryName(meadowUpdaterPath), tempUpdaterDir, MEADOW_UPDATER);
+
+		// Supporting files required in the temp directory
+		CopyMeadowUpdaterFiles(Path.GetDirectoryName(meadowUpdaterPath), tempUpdaterDir, CLIFX);
+
+		string commandArguments = $"update -t {MEADOW_CLI}";
+		if (!string.IsNullOrWhiteSpace(Version))
+		{
+			commandArguments += $" -v {Version}";
+		}
+
+		await AppTools.RunProcessCommand("dotnet", $"{Path.Combine(tempUpdaterDir, $"{MEADOW_UPDATER}.dll")} {commandArguments}", cancellationToken: CancellationToken);
+	}
+
+	internal static void CopyMeadowUpdaterFiles(string? sourceDirectory, string targetDirectory, string filesToCopy)
+	{
+		if (sourceDirectory == null)
+		{
+			return;
+		}
+
+		var toolUpdaterFiles = Directory.GetFiles(sourceDirectory, $"{filesToCopy}*");
+		foreach (var file in toolUpdaterFiles)
+		{
+			string fileName = Path.GetFileName(file);
+			string destFile = Path.Combine(targetDirectory, fileName);
+			File.Copy(file, destFile, true);
+		}
+	}
+}

--- a/Source/v2/Meadow.Cli/Meadow.CLI.csproj
+++ b/Source/v2/Meadow.Cli/Meadow.CLI.csproj
@@ -46,6 +46,7 @@
     <ProjectReference Include="..\Meadow.Dfu\Meadow.Dfu.csproj" />
     <ProjectReference Include="..\Meadow.Linker\Meadow.Linker.csproj" />
     <ProjectReference Include="..\Meadow.Tooling.Core\Meadow.Tooling.Core.csproj" />
+    <ProjectReference Include="..\Meadow.Updater\Meadow.Updater.csproj" />
     <ProjectReference Include="..\Meadow.UsbLib\Meadow.UsbLib.csproj" />
   </ItemGroup>
   
@@ -62,4 +63,13 @@
   <ItemGroup>
     <None Include="..\..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="..\Meadow.Updater\bin\$(Configuration)\net8.0\Meadow.Updater.exe">
+      <Pack>true</Pack>
+      <PackagePath>tools\net8.0\any\</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Source/v2/Meadow.Cli/Strings.cs
+++ b/Source/v2/Meadow.Cli/Strings.cs
@@ -1,4 +1,5 @@
-﻿using Meadow.Telemetry;
+﻿using System.Numerics;
+using Meadow.Telemetry;
 
 namespace Meadow.CLI;
 
@@ -85,5 +86,14 @@ You can change your mind at any time by running the ""[bold]meadow telemetry [[e
 ";
 
         public const string AskToParticipate = "Would you like to participate?";
+    }
+
+    public static class Update
+    {
+        public const string Description = "Update WildernessLabs.Meadow.CLI";
+        public const string Updating = "Updating {0}";
+        public const string Instruction1 = "This will initially uninstall {0} and will then install version {1}";
+        public const string Instruction2 = "Please wait about 10s to allow the above steps to complete.";
+        public const string UpdaterNotFound = "Meadow.Updater not found.";
     }
 }

--- a/Source/v2/Meadow.Updater/Meadow.Updater.csproj
+++ b/Source/v2/Meadow.Updater/Meadow.Updater.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>11</LangVersion>
+    <Platforms>AnyCPU</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\MeadowCLIKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CliFx" Version="*" />
+  </ItemGroup>
+</Project>

--- a/Source/v2/Meadow.Updater/Program.cs
+++ b/Source/v2/Meadow.Updater/Program.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using CliFx;
+using CliFx.Exceptions;
+using System.Diagnostics;
+
+namespace Meadow.Updater;
+
+public class Program
+{
+	public static async Task<int> Main(string[] args)
+	{
+        int returnCode;
+
+        try
+        {
+            returnCode = await new CliApplicationBuilder()
+                .AddCommandsFromThisAssembly()
+                //.UseTypeActivator(serviceProvider.GetService!)
+                .SetExecutableName("Meadow.Updater")
+                .Build()
+                .RunAsync();
+        }
+        catch (CommandException ce)
+        {
+            returnCode = ce.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Operation failed: {ex.Message}");
+            returnCode = 1;
+        }
+
+		return returnCode;
+	}
+}

--- a/Source/v2/Meadow.Updater/Strings.cs
+++ b/Source/v2/Meadow.Updater/Strings.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Meadow.Updater;
+
+public static class Strings
+{
+    public static class Update
+    {
+        public const string Description = "Update the specified tool";
+        public const string NoToolSpecified = "No tool specified. Exiting.";
+    }
+}

--- a/Source/v2/Meadow.Updater/UpdateToolCommand.cs
+++ b/Source/v2/Meadow.Updater/UpdateToolCommand.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Diagnostics;
+using CliFx;
+using CliFx.Attributes;
+using CliFx.Infrastructure;
+
+namespace Meadow.Updater;
+
+[Command("update", Description = Strings.Update.Description)]
+public class UpdateToolCommand : ICommand
+{
+    const int DEFAULT_DELAY_SECONDS = 2;
+
+    [CommandOption("tool", 't', IsRequired = false)]
+    public string? Tool { get; set; }
+
+    [CommandOption("version", 'v', IsRequired = false)]
+    public string? Version { get; set; }
+
+    public async ValueTask ExecuteAsync(IConsole console)
+    {
+        if (string.IsNullOrWhiteSpace(Tool))
+        {
+            console.Error.WriteLine(Strings.Update.NoToolSpecified);
+            return;
+        }
+
+        // Wait for the specified delay to ensure the process that called this has exited
+        await Task.Delay(TimeSpan.FromSeconds(DEFAULT_DELAY_SECONDS));
+
+        // Uninstall the previous version in case we're updating to a previous Version 
+        await RunCommand("dotnet", $"tool uninstall {Tool} --global", console);
+
+        if (!string.IsNullOrWhiteSpace(Version))
+        {
+            Tool += $" --version {Version}";
+        }
+
+        // Now do the update
+        await RunCommand("dotnet", $"tool update {Tool} --global", console);
+    }
+
+    internal static async Task RunCommand(string command, string arguments, IConsole console)
+    {
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = command,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using (var process = Process.Start(processStartInfo))
+        {
+            while (!process.StandardOutput.EndOfStream)
+            {
+                var line = await process.StandardOutput.ReadLineAsync();
+                console.Output.WriteLine(line ?? string.Empty);
+            }
+
+            while (!process.StandardError.EndOfStream)
+            {
+                var line = await process.StandardError.ReadLineAsync();
+                console.Error.WriteLine(line ?? string.Empty);
+            }
+
+            await process.WaitForExitAsync();
+        }
+    }
+}


### PR DESCRIPTION
Command to reduce customer paper cuts when needing to update Meadow.CLI. 
It is easier for customers to remember `meadow update`, which will update to the latest version, rather than remembering:
```
> dotnet tool update WildernessLabs.Meadow.CLI --global
```

We could also allow them to roll back to specific versions, should something break or become unstable in vLatest. Obviously not too far back as then `meadow update` wouldn't be available.

Tested on:
- [x] Windows
- [x] Mac
- [x] Linux

When run on Mac and Linux this is the output:
```
16:36:35 ~/Downloads $ meadow update
Updating WildernessLabs.Meadow.CLI
This will initially uninstall WildernessLabs.Meadow.CLI and will then install version vLatest
Please wait about 10s to allow the above steps to complete.
16:36:50 ~/Downloads $ Tool 'wildernesslabs.meadow.cli' (version '2.0.47') was successfully uninstalled.
Skipping NuGet package signature verification.
You can invoke the tool using the following command: meadow
Tool 'wildernesslabs.meadow.cli' (version '2.0.48') was successfully installed.
```