### PR TITLE
Add ProjectLab to meadow_link.xml file.

### DIFF
--- a/Meadow.CLI.Core/lib/meadow_link.xml
+++ b/Meadow.CLI.Core/lib/meadow_link.xml
@@ -9,4 +9,5 @@
     <assembly fullname="SQLite-net" />
     <assembly fullname="MQTTnet" />
     <assembly fullname="System.Configuration" />
+    <assembly fullname="ProjectLab" />
 </linker>


### PR DESCRIPTION
Worth noting: the v1 `meadow_link.xml` file also includes assembly fullname=“System.Configuration” which the v2 `meadow_link.xml` does NOT.