### PR TITLE
Fix edge case where passed in configuration doesn't exist in app path.

### DIFF
--- a/Source/v2/Meadow.CLI/Commands/Current/App/AppTools.cs
+++ b/Source/v2/Meadow.CLI/Commands/Current/App/AppTools.cs
@@ -63,15 +63,24 @@ internal static class AppTools
 
         if (configuration is not null)
         {
-            file = candidates
-                .Where(c => c.DirectoryName.IndexOf(configuration, StringComparison.OrdinalIgnoreCase) >= 0)
+            var foundConfiguration = candidates.Where(c => c.DirectoryName?.IndexOf(configuration, StringComparison.OrdinalIgnoreCase) >= 0);
+
+            if (foundConfiguration.Count() == 0)
+            {
+                logger?.LogError($"{Strings.NoCompiledApplicationFound} {Strings.WithConfiguration} '{configuration}' {Strings.At} '{path}'");
+                return false;
+            }
+            else
+            {
+                file = foundConfiguration
                 .OrderByDescending(c => c.LastWriteTime)
                 .First();
 
-            if (file == null)
-            {
-                logger?.LogError($"{Strings.NoCompiledApplicationFound} at '{path}'");
-                return false;
+                if (file == null)
+                {
+                    logger?.LogError($"{Strings.NoCompiledApplicationFound} {Strings.At} '{path}'");
+                    return false;
+                }
             }
         }
         else

--- a/Source/v2/Meadow.Cli/Strings.cs
+++ b/Source/v2/Meadow.Cli/Strings.cs
@@ -70,9 +70,10 @@ public static class Strings
     public const string AppDeployFailed = "Application deploy failed";
     public const string AppDeployedSuccessfully = "Application deployed successfully";
     public const string AppTrimFailed = "Application trimming failed";
+	public const string WithConfiguration = "with configuration";
+	public const string At = "at";
 
-
-    public static class Telemetry
+	public static class Telemetry
     {
         public const string ConsentMessage = @$"
 Let's improve the Meadow experience together


### PR DESCRIPTION
Without this check we get a `Sequence contains no elements` error and the next Linq block blows up.