### PR TITLE
Allows us to pass in DebuggerName, for better UX

### DIFF
--- a/Source/Meadow.HCom/Debugging/DebuggingServer.ActiveClient.cs
+++ b/Source/Meadow.HCom/Debugging/DebuggingServer.ActiveClient.cs
@@ -17,8 +17,9 @@ public partial class DebuggingServer
         private readonly ILogger? _logger;
         private bool _disposed;
         private readonly BlockingCollection<byte[]> _debuggerMessages = new();
+        private readonly string _debuggerName;
 
-        internal ActiveClient(IMeadowConnection connection, ILogger? logger, CancellationToken? cancellationToken)
+        internal ActiveClient(IMeadowConnection connection, ILogger? logger, CancellationToken? cancellationToken, string debuggerName = "Visual Studio")
         {
             _cts = cancellationToken != null
                 ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken.Value)
@@ -27,6 +28,7 @@ public partial class DebuggingServer
             _logger = logger;
             _connection = connection;
             _connection.DebuggerMessageReceived += MeadowConnection_DebuggerMessageReceived;
+            _debuggerName = debuggerName;
         }
 
         public async Task Start(TcpListener tcpListener)
@@ -83,22 +85,22 @@ public partial class DebuggingServer
                     }
                     else
                     {
-                        _logger?.LogInformation("Unable to Read Data from Visual Studio");
-                        _logger?.LogTrace("Unable to Read Data from Visual Studio");
+                        _logger?.LogInformation($"Unable to Read Data from {_debuggerName}");
+                        _logger?.LogTrace($"Unable to Read Data from {_debuggerName}");
                     }
                 }
             }
             catch (IOException ioe)
             {
-                _logger?.LogInformation("Visual Studio has Disconnected");
+                _logger?.LogInformation($"{_debuggerName} has Disconnected");
             }
             catch (ObjectDisposedException ode)
             {
-                _logger?.LogInformation("Visual Studio has stopped debugging");
+                _logger?.LogInformation($"{_debuggerName} has stopped debugging");
             }
             catch (Exception ex)
             {
-                _logger?.LogError($"Error receiving data from Visual Studio.\nError: {ex.Message}\nStackTrace:\n{ex.StackTrace}");
+                _logger?.LogError($"Error receiving data from {_debuggerName}.\nError: {ex.Message}\nStackTrace:\n{ex.StackTrace}");
                 throw;
             }
         }
@@ -117,7 +119,7 @@ public partial class DebuggingServer
                     _logger?.LogTrace("Received {count} bytes from Meadow, will forward to VS", byteData.Length);
                     if (!_tcpClient.Connected || _networkStream == null || !_networkStream.CanWrite)
                     {
-                        _logger?.LogDebug("Cannot forward data, Visual Studio is not connected");
+                        _logger?.LogDebug($"Cannot forward data, {_debuggerName} is not connected");
                         break;
                     }
 
@@ -133,7 +135,7 @@ public partial class DebuggingServer
             }
             catch (Exception ex)
             {
-                _logger?.LogError($"Error sending data to Visual Studio.\nError: {ex.Message}\nStackTrace:\n{ex.StackTrace}");
+                _logger?.LogError($"Error sending data to {_debuggerName}.\nError: {ex.Message}\nStackTrace:\n{ex.StackTrace}");
 
                 if (!_cts.Token.IsCancellationRequested)
                 {

--- a/Source/Meadow.HCom/Debugging/DebuggingServer.cs
+++ b/Source/Meadow.HCom/Debugging/DebuggingServer.cs
@@ -15,6 +15,7 @@ public partial class DebuggingServer : IDisposable
     private CancellationTokenSource? _cancellationTokenSource;
     private readonly ILogger? _logger;
     private readonly IMeadowConnection _connection;
+    private readonly string _debuggerName;
     private ActiveClient? _activeClient;
     private readonly TcpListener _listener;
     private readonly Task? _listenerTask;
@@ -27,10 +28,11 @@ public partial class DebuggingServer : IDisposable
     /// <param name="connection">The <see cref="IMeadowConnection"/>meadow connection</param>
     /// <param name="localEndpoint">The <see cref="IPEndPoint"/> to listen for incoming debugger connections</param>
     /// <param name="logger">The <see cref="ILogger"/> to logging state information</param>
-    public DebuggingServer(IMeadowConnection connection, int port, ILogger? logger)
+    public DebuggingServer(IMeadowConnection connection, int port, ILogger? logger, string debuggerName = "Visual Studo")
     {
         _logger = logger;
         _connection = connection;
+        _debuggerName = debuggerName;
 
         var endPoint = new IPEndPoint(IPAddress.Loopback, port);
 
@@ -47,7 +49,7 @@ public partial class DebuggingServer : IDisposable
         _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         _listener.Start();
-        _logger?.LogInformation($"Listening for Visual Studio to connect");
+        _logger?.LogInformation($"Listening for {_debuggerName} to connect");
 
         // This call will wait for the client to connect, before continuing.
         _activeClient = await CreateActiveClient(_listener);
@@ -87,7 +89,7 @@ public partial class DebuggingServer : IDisposable
         }
         catch (Exception ex)
         {
-            _logger?.LogError(ex, "An error occurred while connecting to Visual Studio");
+            _logger?.LogError(ex, $"An error occurred while connecting to {_debuggerName}");
         }
         return null;
     }


### PR DESCRIPTION
So that from each debugger extension we can pass, **Rider**, **VSCode** and potentially others in future, for more accurate messages.