### PR TITLE
Ensure on Mac we return the right path, regardless of .NET version

### DIFF
--- a/Source/Meadow.SoftwareManager/F7FirmwarePackageCollection.cs
+++ b/Source/Meadow.SoftwareManager/F7FirmwarePackageCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Meadow.Software;
@@ -21,6 +22,9 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
     /// The default root directory for storing F7 firmware packages.
     /// </summary>
     public static string DefaultF7FirmwareStoreRoot = Path.Combine(
+        RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+        ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            "Library", "Application Support") :
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "WildernessLabs",
         "Firmware");


### PR DESCRIPTION
Run the following code in a csproj with .NET 8 or an earlier .NET  like 7 on macOS, it will give different results for `LocalApplicationData`:

```
using System;

internal class Program
{
    /// <summary>
    /// The main entry point for the application. 
    /// This creates an instance of your game and calls it's Run() method 
    /// </summary>
    /// <param name="args">Command-line arguments passed to the application.</param>
    private static void Main(string[] args)
    {
        Console.WriteLine($"Environment Version: {Environment.Version}"); // e.g., "7.0.0" vs. "8.0.0"
        Console.WriteLine($"FrameworkDescription: {System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription}");
        Console.WriteLine($"LocalApplicationData: {Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)}");

        Console.ReadLine();
    }
}
```
eg.
.NET 7 and earlier returns : `/Users/UserName/.local/share`
.NET 8 returns : `/Users/UserName/Library/Application` - This is what `meadow` command line uses for firmware download location.