### PR TITLE
Scope TFM override to main project only (3.0.0-beta2)

### DIFF
--- a/Source/Meadow.CLI/Meadow.CLI.csproj
+++ b/Source/Meadow.CLI/Meadow.CLI.csproj
@@ -10,7 +10,7 @@
     <Authors>Wilderness Labs, Inc</Authors>
     <Company>Wilderness Labs, Inc</Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>3.0.0-beta1</PackageVersion>
+    <PackageVersion>3.0.0-beta2</PackageVersion>
     <Platforms>AnyCPU</Platforms>
     <PackageProjectUrl>http://developer.wildernesslabs.co/Meadow/Meadow.CLI/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/WildernessLabs/Meadow.CLI</RepositoryUrl>

--- a/Source/Meadow.CLI/Properties/AssemblyInfo.cs
+++ b/Source/Meadow.CLI/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ public static class Constants
     public const string CLI_VERSION = "3.0.0.0";
     // AssemblyInformationalVersion accepts SemVer 2.0 strings including pre-release tags;
     // CliFx reads this for `--version` output
-    public const string CLI_INFORMATIONAL_VERSION = "3.0.0-beta1";
+    public const string CLI_INFORMATIONAL_VERSION = "3.0.0-beta2";
 }

--- a/Source/Meadow.Tooling.Core/App/BuildManager.cs
+++ b/Source/Meadow.Tooling.Core/App/BuildManager.cs
@@ -239,15 +239,19 @@ public partial class BuildManager : IBuildManager
 
         var meadowAssembliesPath = GetAssemblyPathForOS(osVersion);
         var targetsFile = Path.Combine(Path.GetTempPath(), $"Meadow.Trimming.{Guid.NewGuid():N}.targets");
+        var propsFile = Path.Combine(Path.GetTempPath(), $"Meadow.Trimming.{Guid.NewGuid():N}.props");
 
         // Only override TFM for legacy projects (e.g. netstandard2.1) that can't natively
-        // use PublishTrimmed. Modern net10.0+ projects don't need this and it breaks
-        // Microsoft.NET.Build.Containers.targets in referenced projects.
+        // use PublishTrimmed. Modern net10.0+ projects don't need this.
         var needsTfmOverride = NeedsTfmOverrideForTrimming(projectFilePath);
+        var mainProjectFullPath = File.Exists(projectFilePath)
+            ? Path.GetFullPath(projectFilePath)
+            : (Directory.GetFiles(projectFilePath, "*.csproj").FirstOrDefault() is { } p ? Path.GetFullPath(p) : Path.GetFullPath(projectFilePath));
 
         try
         {
             File.WriteAllText(targetsFile, MeadowTrimmingTargets);
+            File.WriteAllText(propsFile, MeadowTrimmingProps);
 
             using var proc = new Process();
             proc.StartInfo.FileName = "dotnet";
@@ -255,11 +259,17 @@ public partial class BuildManager : IBuildManager
             // cascade to netstandard2.1 referenced projects and trigger NETSDK1124.
             // Self-contained + linux-arm RID is required for trimming to include BCL assemblies.
             // PublishDir ensures output goes where the CLI expects (not under a RID subfolder).
+            // CustomBeforeMicrosoftCommonProps loads the props file for every project in the graph,
+            // but its TFM override is scoped to MSBuildProjectFullPath == MeadowMainProject so
+            // referenced (e.g. netstandard2.0) projects keep their original TFM and don't trip
+            // Microsoft.NET.Build.Containers.targets with MSB4184.
             var args = $"publish \"{projectFilePath}\" -c \"{configuration}\"" +
                 $" --self-contained -r linux-arm" +
                 $" -p:AppendRuntimeIdentifierToOutputPath=false" +
+                $" -p:CustomBeforeMicrosoftCommonProps=\"{propsFile}\"" +
                 $" -p:CustomAfterMicrosoftCommonTargets=\"{targetsFile}\"" +
-                $" -p:MeadowAssembliesPath=\"{meadowAssembliesPath}\"";
+                $" -p:MeadowAssembliesPath=\"{meadowAssembliesPath}\"" +
+                $" -p:MeadowMainProject=\"{mainProjectFullPath}\"";
 
             // Always set PublishDir explicitly. Without it, --self-contained -r linux-arm
             // creates a {RID}/ subdirectory that doesn't match where the CLI looks for output.
@@ -294,10 +304,10 @@ public partial class BuildManager : IBuildManager
             {
                 // Detect the latest installed .NETCoreApp SDK and target that — .NET is backwards-compatible
                 // so the highest available version is the safest choice for legacy projects whose own TFM
-                // (netstandard2.1, netcoreappX) can't natively use PublishTrimmed.
+                // (netstandard2.1, netcoreappX) can't natively use PublishTrimmed. The props file applies
+                // this only to the main project, not its referenced projects.
                 var tfmVersion = GetLatestNetCoreAppVersion();
-                args += $" -p:TargetFrameworkIdentifier=.NETCoreApp" +
-                        $" -p:TargetFrameworkVersion={tfmVersion}";
+                args += $" -p:MeadowOverrideTfmVersion={tfmVersion}";
             }
 
             proc.StartInfo.Arguments = args;
@@ -342,8 +352,20 @@ public partial class BuildManager : IBuildManager
         finally
         {
             try { File.Delete(targetsFile); } catch { }
+            try { File.Delete(propsFile); } catch { }
         }
     }
+
+    // MSBuild .props injected via CustomBeforeMicrosoftCommonProps. Loaded for every project
+    // in the graph, but its overrides are scoped to the main project only via MeadowMainProject
+    // matching MSBuildProjectFullPath. Referenced (netstandard) projects keep their original TFM
+    // — without this scoping, the override would cascade and trip Containers.targets (MSB4184).
+    private const string MeadowTrimmingProps = @"<Project>
+  <PropertyGroup Condition=""'$(MeadowOverrideTfmVersion)' != '' AND '$(MSBuildProjectFullPath)' == '$(MeadowMainProject)'"">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>$(MeadowOverrideTfmVersion)</TargetFrameworkVersion>
+  </PropertyGroup>
+</Project>";
 
     // MSBuild targets injected into dotnet publish to configure trimming for Meadow:
     // - Swaps standard .NET BCL assemblies with Meadow's custom BCL in both


### PR DESCRIPTION
## Summary

- Move the legacy-project TFM override (`TargetFrameworkIdentifier=.NETCoreApp`, `TargetFrameworkVersion=v10.0`) out of the dotnet publish command line and into a `.props` file injected via `CustomBeforeMicrosoftCommonProps`.
- Scope the override to the main project only (`MSBuildProjectFullPath == MeadowMainProject`) so it no longer cascades to referenced netstandard projects.
- Bump CLI to `3.0.0-beta2`.

Fixes the `MSB4184: VersionGreaterThanOrEquals('', 8.0)` failure from `Microsoft.NET.Build.Containers.targets` that hit any V3 deploy of a project graph containing netstandard references (e.g. ProjectLab apps).

## Test plan

- [x] Deploy a netstandard2.1 main project that pulls in netstandard reference projects (ProjectLab_Demo) — publish completes, MONO starts on device.
- [x] Deploy a net10.0 main project (BlinkyCS) still works as before.
- [x] CLI builds clean for both netstandard2.0 and net8.0 targets of Meadow.Tooling.Core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)