### PR TITLE
Download firmware from the public S3 bucket instead of Meadow.Cloud

### DIFF
--- a/Source/Meadow.CLI/Commands/Firmware/FirmwareDownloadCommand.cs
+++ b/Source/Meadow.CLI/Commands/Firmware/FirmwareDownloadCommand.cs
@@ -1,24 +1,21 @@
 ﻿using CliFx.Attributes;
 using Meadow.CLI.Commands.DeviceManagement;
-using Meadow.Cloud.Client;
 using Meadow.Software;
 using Microsoft.Extensions.Logging;
 
 namespace Meadow.CLI.Commands.Firmware;
 
 [Command("firmware download", Description = "Download a firmware package")]
-public class FirmwareDownloadCommand : BaseCloudCommand<FirmwareDownloadCommand>
+public class FirmwareDownloadCommand : BaseCommand<FirmwareDownloadCommand>
 {
     private readonly FileManager _fileManager;
 
     public FirmwareDownloadCommand(
         FileManager fileManager,
-        IMeadowCloudClient meadowCloudClient,
         ILoggerFactory loggerFactory)
-        : base(meadowCloudClient, loggerFactory)
+        : base(loggerFactory)
     {
         _fileManager = fileManager;
-        RequiresAuthentication = false;
     }
 
     [CommandOption("force", 'f', IsRequired = false)]
@@ -27,7 +24,7 @@ public class FirmwareDownloadCommand : BaseCloudCommand<FirmwareDownloadCommand>
     [CommandOption("version", 'v', IsRequired = false)]
     public string? Version { get; set; }
 
-    protected override async ValueTask ExecuteCloudCommand()
+    protected override async ValueTask ExecuteCommand()
     {
         await _fileManager.Refresh();
 

--- a/Source/Meadow.CLI/Meadow.CLI.csproj
+++ b/Source/Meadow.CLI/Meadow.CLI.csproj
@@ -10,7 +10,7 @@
     <Authors>Wilderness Labs, Inc</Authors>
     <Company>Wilderness Labs, Inc</Company>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>3.0.0-beta1</PackageVersion>
+    <PackageVersion>3.0.0-beta4</PackageVersion>
     <Platforms>AnyCPU</Platforms>
     <PackageProjectUrl>http://developer.wildernesslabs.co/Meadow/Meadow.CLI/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/WildernessLabs/Meadow.CLI</RepositoryUrl>

--- a/Source/Meadow.SoftwareManager/F7FirmwareDownloadManager.cs
+++ b/Source/Meadow.SoftwareManager/F7FirmwareDownloadManager.cs
@@ -1,19 +1,43 @@
 ﻿using System;
 using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Meadow.Software;
 
+/// <summary>
+/// Retrieves F7 firmware release metadata and packages from the public Wilderness Labs download bucket.
+/// No Meadow.Cloud account or authentication is required.
+/// </summary>
 internal class F7FirmwareDownloadManager
 {
-    private readonly IMeadowCloudClient _meadowCloudClient;
+    /// <summary>
+    /// The default (public, unauthenticated) firmware source. Release metadata is published as
+    /// <c>latest.json</c> and <c>{version}.json</c> under this root, alongside the package zips.
+    /// </summary>
+    public const string DefaultFirmwareSourceUrl = "https://s3-us-west-2.amazonaws.com/downloads.wildernesslabs.co/Meadow_Beta/";
+
+    private static readonly Lazy<HttpClient> s_defaultHttpClient = new(() => new HttpClient());
+
+    private readonly HttpClient _httpClient;
+    private readonly Uri _sourceRoot;
 
     public event EventHandler<long> DownloadProgress = default!;
 
-    public F7FirmwareDownloadManager(IMeadowCloudClient meadowCloudClient)
+    public F7FirmwareDownloadManager(HttpClient? httpClient = null, string? sourceUrl = null)
     {
-        _meadowCloudClient = meadowCloudClient;
+        _httpClient = httpClient ?? s_defaultHttpClient.Value;
+
+        var root = string.IsNullOrWhiteSpace(sourceUrl) ? DefaultFirmwareSourceUrl : sourceUrl!.Trim();
+        if (!root.EndsWith("/"))
+        {
+            root += "/";
+        }
+
+        _sourceRoot = new Uri(root, UriKind.Absolute);
     }
 
     public async Task<string> GetLatestAvailableVersion()
@@ -25,21 +49,28 @@ internal class F7FirmwareDownloadManager
 
     public async Task<F7ReleaseMetadata?> GetReleaseMetadata(string? version = null, CancellationToken cancellationToken = default)
     {
-        version = string.IsNullOrWhiteSpace(version) ? "latest" : version;
-        var response = await _meadowCloudClient.Firmware.GetVersion("Meadow_Beta", version!, cancellationToken);
+        version = string.IsNullOrWhiteSpace(version) ? "latest" : version!.Trim();
+        var uri = new Uri(_sourceRoot, $"{version}.json");
 
-        if (response == null)
+        using var response = await _httpClient.GetAsync(uri, cancellationToken);
+
+        // S3 answers 404 (or 403 when listing is disabled) for a key that does not exist
+        if (response.StatusCode == HttpStatusCode.NotFound || response.StatusCode == HttpStatusCode.Forbidden)
         {
             return null;
         }
 
-        return new F7ReleaseMetadata()
+        EnsureSuccess(response, uri);
+
+        var json = await response.Content.ReadAsStringAsync();
+        var metadata = JsonSerializer.Deserialize<F7ReleaseMetadata>(json);
+
+        if (metadata == null || string.IsNullOrWhiteSpace(metadata.Version))
         {
-            Version = response.Version,
-            MinCLIVersion = response.MinCLIVersion,
-            DownloadURL = response.DownloadUrl,
-            NetworkDownloadURL = response.NetworkDownloadUrl
-        };
+            return null;
+        }
+
+        return metadata;
     }
 
     public void SetDefaultVersion(string destinationRoot, string version)
@@ -140,13 +171,13 @@ internal class F7FirmwareDownloadManager
 
     private async Task<string> DownloadFile(Uri uri, CancellationToken cancellationToken = default)
     {
-        using var response = await _meadowCloudClient.Firmware.GetDownloadResponse(uri, cancellationToken);
+        using var response = await _httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+        EnsureSuccess(response, uri);
 
         var downloadFileName = Path.GetTempFileName();
 
         using var stream = await response.Content.ReadAsStreamAsync();
-
-        var contentLength = response.Content.Headers.ContentLength;
 
         using var downloadFileStream = new DownloadFileStream(stream);
         using var firmwareFile = File.OpenWrite(downloadFileName);
@@ -156,5 +187,16 @@ internal class F7FirmwareDownloadManager
         await downloadFileStream.CopyToAsync(firmwareFile);
 
         return downloadFileName;
+    }
+
+    private static void EnsureSuccess(HttpResponseMessage response, Uri uri)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        throw new HttpRequestException(
+            $"Request to '{uri}' failed with status {(int)response.StatusCode} ({response.ReasonPhrase}).");
     }
 }

--- a/Source/Meadow.SoftwareManager/F7FirmwarePackageCollection.cs
+++ b/Source/Meadow.SoftwareManager/F7FirmwarePackageCollection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
@@ -55,9 +56,9 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
     /// <summary>
     /// Initializes a new instance of the <see cref="F7FirmwarePackageCollection"/> class.
     /// </summary>
-    /// <param name="meadowCloudClient">The Meadow cloud client.</param>
-    internal F7FirmwarePackageCollection(IMeadowCloudClient meadowCloudClient)
-        : this(DefaultF7FirmwareStoreRoot, meadowCloudClient)
+    /// <param name="httpClient">Optional HTTP client used to retrieve firmware packages.</param>
+    internal F7FirmwarePackageCollection(HttpClient? httpClient = null)
+        : this(DefaultF7FirmwareStoreRoot, httpClient)
     {
     }
 
@@ -65,10 +66,11 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
     /// Initializes a new instance of the <see cref="F7FirmwarePackageCollection"/> class.
     /// </summary>
     /// <param name="rootPath">The root path for storing firmware packages.</param>
-    /// <param name="meadowCloudClient">The Meadow cloud client.</param>
-    public F7FirmwarePackageCollection(string rootPath, IMeadowCloudClient meadowCloudClient)
+    /// <param name="httpClient">Optional HTTP client used to retrieve firmware packages.</param>
+    /// <param name="firmwareSourceUrl">Optional base URL of the firmware package source. Defaults to the public Wilderness Labs download bucket.</param>
+    public F7FirmwarePackageCollection(string rootPath, HttpClient? httpClient = null, string? firmwareSourceUrl = null)
     {
-        _downloadManager = new F7FirmwareDownloadManager(meadowCloudClient);
+        _downloadManager = new F7FirmwareDownloadManager(httpClient, firmwareSourceUrl);
 
         if (!Directory.Exists(rootPath))
         {
@@ -92,7 +94,7 @@ public class F7FirmwarePackageCollection : IFirmwarePackageCollection
     }
 
     /// <summary>
-    /// Checks the remote (i.e. cloud) store to see if a new firmware package is available.
+    /// Checks the remote firmware source to see if a new firmware package is available.
     /// </summary>
     /// <returns>A version number if an update is available, otherwise null.</returns>
     public async Task<string?> UpdateAvailable()

--- a/Source/Meadow.SoftwareManager/FileManager.cs
+++ b/Source/Meadow.SoftwareManager/FileManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Meadow.Software;
@@ -13,10 +14,10 @@ public class FileManager
 
     public FirmwareStore Firmware { get; }
 
-    public FileManager(IMeadowCloudClient meadowCloudClient)
+    public FileManager(HttpClient? httpClient = null)
     {
         Firmware = new FirmwareStore();
-        var f7Collection = new F7FirmwarePackageCollection(meadowCloudClient);
+        var f7Collection = new F7FirmwarePackageCollection(httpClient);
         Firmware.AddCollection("Meadow F7", f7Collection);
     }
 

--- a/Source/Meadow.SoftwareManager/Meadow.SoftwareManager.Rider.csproj
+++ b/Source/Meadow.SoftwareManager/Meadow.SoftwareManager.Rider.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="System.IO.Hashing" Version="7.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Meadow.Cloud.Client\Meadow.Cloud.Client.Rider.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/Source/Meadow.SoftwareManager/Meadow.SoftwareManager.csproj
+++ b/Source/Meadow.SoftwareManager/Meadow.SoftwareManager.csproj
@@ -17,8 +17,4 @@
     <PackageReference Include="System.IO.Hashing" Version="8.*" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Meadow.Cloud.Client\Meadow.Cloud.Client.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/Source/Meadow.SoftwareManager/Usings.cs
+++ b/Source/Meadow.SoftwareManager/Usings.cs
@@ -1,5 +1,4 @@
-﻿global using Meadow.Cloud.Client;
-global using System.Collections;
+﻿global using System.Collections;
 global using System.IO.Compression;
 global using System.IO.Hashing;
 global using System.Runtime.CompilerServices;

--- a/Source/Meadow.Tooling.Core/Meadow.Tooling.Core.csproj
+++ b/Source/Meadow.Tooling.Core/Meadow.Tooling.Core.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Meadow.Cloud.Client\Meadow.Cloud.Client.csproj" />
     <ProjectReference Include="..\Meadow.HCom\Meadow.HCom.csproj" />
     <ProjectReference Include="..\Meadow.Linker\Meadow.Linker.csproj" />
     <ProjectReference Include="..\Meadow.SoftwareManager\Meadow.SoftwareManager.csproj" />

--- a/Source/Tests/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetLatestAvailableVersionTests.cs
+++ b/Source/Tests/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetLatestAvailableVersionTests.cs
@@ -2,38 +2,32 @@
 
 public class GetLatestAvailableVersionTests
 {
+    private const string Source = "https://example.org/firmware/";
+
     [Fact]
     public async Task GetLatestAvailableVersion_WithLatestVersionFound_ShouldReturnVersion()
     {
         // Arrange
-        var version = new GetFirmwareVersionResponse(
-            version: "1.8.0.0",
-            minCLIVersion: "1.8.0.0",
-            downloadUrl: $"https://example.org/api/v1/firmware/Meadow_Beta/Meadow.OS_1.8.0.0.zip",
-            networkDownloadUrl: $"https://example.org/api/v1/firmware/Meadow_Beta/Meadow.Network_1.8.0.0.zip");
-
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
-
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "latest", A<CancellationToken>._))
-         .Returns(version);
+        var handler = new StubHttpMessageHandler()
+            .Map(Source + "latest.json", HttpStatusCode.OK, """
+                {"version":"1.8.0.0","minCLIVersion":"1.8.0.0","downloadUrl":"https://example.org/firmware/Meadow.OS_1.8.0.0.zip","networkDownloadUrl":"https://example.org/firmware/Meadow.Network_1.8.0.0.zip"}
+                """);
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
         var result = await downloadManager.GetLatestAvailableVersion();
 
         // Assert
         Assert.Equal("1.8.0.0", result);
+        Assert.Equal(new Uri(Source + "latest.json"), Assert.Single(handler.Requests));
     }
 
     [Fact]
     public async Task GetLatestAvailableVersion_WithLatestVersionNotFound_ShouldReturnEmptyString()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
-
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "latest", A<CancellationToken>._))
-         .Returns((GetFirmwareVersionResponse?)null);
+        var handler = new StubHttpMessageHandler();
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
         var result = await downloadManager.GetLatestAvailableVersion();
@@ -46,21 +40,29 @@ public class GetLatestAvailableVersionTests
     public async Task GetLatestAvailableVersion_WithVersionThatReturnsErrorResponse_ShouldThrowException()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
-
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "latest", A<CancellationToken>._))
-         .ThrowsAsync(new MeadowCloudException("Test message.", HttpStatusCode.Unauthorized, null, new Dictionary<string, IEnumerable<string>>(), null));
+        var handler = new StubHttpMessageHandler()
+            .Map(Source + "latest.json", HttpStatusCode.InternalServerError);
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => downloadManager.GetLatestAvailableVersion());
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => downloadManager.GetLatestAvailableVersion());
 
         // Assert
-        Assert.Equal(@"Test message.
+        Assert.Contains("500", ex.Message);
+        Assert.Contains(Source + "latest.json", ex.Message);
+    }
 
-Status: Unauthorized
-Response: 
-(null)", ex.Message);
-        Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+    [Fact]
+    public async Task GetLatestAvailableVersion_WithDefaultSource_ShouldUsePublicBucket()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler();
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient());
+
+        // Act
+        await downloadManager.GetLatestAvailableVersion();
+
+        // Assert
+        Assert.Equal(new Uri(F7FirmwareDownloadManager.DefaultFirmwareSourceUrl + "latest.json"), Assert.Single(handler.Requests));
     }
 }

--- a/Source/Tests/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetReleaseMetadataTests.cs
+++ b/Source/Tests/Meadow.SoftwareManager.Unit.Tests/F7FirmwareDownloadManagerTests/GetReleaseMetadataTests.cs
@@ -2,6 +2,13 @@
 
 public class GetReleaseMetadataTests
 {
+    private const string Source = "https://example.org/firmware/";
+
+    private static string Metadata(string version) =>
+        $$"""
+        {"version":"{{version}}","minCLIVersion":"{{version}}","downloadUrl":"https://example.org/firmware/Meadow.OS_{{version}}.zip","networkDownloadUrl":"https://example.org/firmware/Meadow.Network_{{version}}.zip"}
+        """;
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -9,15 +16,9 @@ public class GetReleaseMetadataTests
     public async Task GetReleaseMetadata_WithNullOrWhiteSpaceVersion_ShouldReturnLatestVersion(string? version)
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
-
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "latest", A<CancellationToken>._))
-         .Returns(new GetFirmwareVersionResponse(
-            version: "1.8.0.0",
-            minCLIVersion: "1.8.0.0",
-            downloadUrl: $"https://example.org/api/v1/firmware/Meadow_Beta/Meadow.OS_1.8.0.0.zip",
-            networkDownloadUrl: $"https://example.org/api/v1/firmware/Meadow_Beta/Meadow.Network_1.8.0.0.zip"));
+        var handler = new StubHttpMessageHandler()
+            .Map(Source + "latest.json", HttpStatusCode.OK, Metadata("1.8.0.0"));
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
         var result = await downloadManager.GetReleaseMetadata(version);
@@ -25,6 +26,9 @@ public class GetReleaseMetadataTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("1.8.0.0", result.Version);
+        Assert.Equal("1.8.0.0", result.MinCLIVersion);
+        Assert.Equal("https://example.org/firmware/Meadow.OS_1.8.0.0.zip", result.DownloadURL);
+        Assert.Equal("https://example.org/firmware/Meadow.Network_1.8.0.0.zip", result.NetworkDownloadURL);
     }
 
     [Theory]
@@ -34,11 +38,8 @@ public class GetReleaseMetadataTests
     public async Task GetReleaseMetadata_WithNullOrWhiteSpaceVersion_AndNoLatestVersion_ShouldReturnNull(string? version)
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
-
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "latest", A<CancellationToken>._))
-         .Returns((GetFirmwareVersionResponse?)null);
+        var handler = new StubHttpMessageHandler();
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
         var result = await downloadManager.GetReleaseMetadata(version);
@@ -51,15 +52,9 @@ public class GetReleaseMetadataTests
     public async Task GetReleaseMetadata_WithSpecificVersion_ShouldReturnVersion()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
-
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "1.7.0.0", A<CancellationToken>._))
-         .Returns(new GetFirmwareVersionResponse(
-            version: "1.7.0.0",
-            minCLIVersion: "1.7.0.0",
-            downloadUrl: $"https://example.org/api/v1/firmware/Meadow_Beta/Meadow.OS_1.7.0.0.zip",
-            networkDownloadUrl: $"https://example.org/api/v1/firmware/Meadow_Beta/Meadow.Network_1.7.0.0.zip"));
+        var handler = new StubHttpMessageHandler()
+            .Map(Source + "1.7.0.0.json", HttpStatusCode.OK, Metadata("1.7.0.0"));
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
         var result = await downloadManager.GetReleaseMetadata("1.7.0.0");
@@ -67,17 +62,30 @@ public class GetReleaseMetadataTests
         // Assert
         Assert.NotNull(result);
         Assert.Equal("1.7.0.0", result.Version);
+        Assert.Equal(new Uri(Source + "1.7.0.0.json"), Assert.Single(handler.Requests));
     }
 
     [Fact]
     public async Task GetReleaseMetadata_WithUnknownVersion_ShouldReturnNull()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
+        var handler = new StubHttpMessageHandler();
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "1.7.0.0", A<CancellationToken>._))
-         .Returns((GetFirmwareVersionResponse?)null);
+        // Act
+        var result = await downloadManager.GetReleaseMetadata("1.7.0.0");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetReleaseMetadata_WithForbiddenResponse_ShouldReturnNull()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler()
+            .Map(Source + "1.7.0.0.json", HttpStatusCode.Forbidden);
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
         var result = await downloadManager.GetReleaseMetadata("1.7.0.0");
@@ -90,21 +98,29 @@ public class GetReleaseMetadataTests
     public async Task GetReleaseMetadata_WithVersionThatReturnsErrorResponse_ShouldThrowException()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var downloadManager = new F7FirmwareDownloadManager(client);
-
-        A.CallTo(() => client.Firmware.GetVersion("Meadow_Beta", "1.8.0.0", A<CancellationToken>._))
-         .ThrowsAsync(new MeadowCloudException("Test message.", HttpStatusCode.Unauthorized, null, new Dictionary<string, IEnumerable<string>>(), null));
+        var handler = new StubHttpMessageHandler()
+            .Map(Source + "1.8.0.0.json", HttpStatusCode.InternalServerError);
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
 
         // Act
-        var ex = await Assert.ThrowsAsync<MeadowCloudException>(() => downloadManager.GetReleaseMetadata("1.8.0.0"));
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => downloadManager.GetReleaseMetadata("1.8.0.0"));
 
         // Assert
-        Assert.Equal(@"Test message.
+        Assert.Contains("500", ex.Message);
+    }
 
-Status: Unauthorized
-Response: 
-(null)", ex.Message);
-        Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+    [Fact]
+    public async Task GetReleaseMetadata_WithEmptyVersionInResponse_ShouldReturnNull()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler()
+            .Map(Source + "latest.json", HttpStatusCode.OK, """{"version":""}""");
+        var downloadManager = new F7FirmwareDownloadManager(handler.CreateClient(), Source);
+
+        // Act
+        var result = await downloadManager.GetReleaseMetadata();
+
+        // Assert
+        Assert.Null(result);
     }
 }

--- a/Source/Tests/Meadow.SoftwareManager.Unit.Tests/F7FirmwarePackageCollectionTests.cs
+++ b/Source/Tests/Meadow.SoftwareManager.Unit.Tests/F7FirmwarePackageCollectionTests.cs
@@ -23,8 +23,7 @@ public class F7FirmwarePackageCollectionTests : IDisposable
     public async Task Refresh_WithNoFiles_ShouldBeEmpty()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var collection = new F7FirmwarePackageCollection(_rootPath, client);
+        var collection = new F7FirmwarePackageCollection(_rootPath);
 
         // Act
         await collection.Refresh();
@@ -37,8 +36,7 @@ public class F7FirmwarePackageCollectionTests : IDisposable
     public async Task Refresh_WithASinglePackage_ShouldHaveOnePackage()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var collection = new F7FirmwarePackageCollection(_rootPath, client);
+        var collection = new F7FirmwarePackageCollection(_rootPath);
 
         var versionPath = Path.Combine(_rootPath, "1.8.0.0");
         Directory.CreateDirectory(versionPath);
@@ -64,8 +62,7 @@ public class F7FirmwarePackageCollectionTests : IDisposable
     public async Task Refresh_WithASinglePackageAndLatestFile_ShouldSetDefaultPackage()
     {
         // Arrange
-        var client = A.Fake<IMeadowCloudClient>();
-        var collection = new F7FirmwarePackageCollection(_rootPath, client);
+        var collection = new F7FirmwarePackageCollection(_rootPath);
 
         var versionPath = Path.Combine(_rootPath, "1.8.0.0");
         Directory.CreateDirectory(versionPath);

--- a/Source/Tests/Meadow.SoftwareManager.Unit.Tests/StubHttpMessageHandler.cs
+++ b/Source/Tests/Meadow.SoftwareManager.Unit.Tests/StubHttpMessageHandler.cs
@@ -1,0 +1,37 @@
+using System.Text;
+
+namespace Meadow.SoftwareManager.Unit.Tests;
+
+/// <summary>
+/// Minimal HTTP handler that maps absolute request URLs to canned responses.
+/// Any URL without a mapping returns 404.
+/// </summary>
+public class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Dictionary<string, (HttpStatusCode Status, string Body)> _responses = new();
+
+    public List<Uri> Requests { get; } = new();
+
+    public StubHttpMessageHandler Map(string url, HttpStatusCode status, string body = "")
+    {
+        _responses[url] = (status, body);
+        return this;
+    }
+
+    public HttpClient CreateClient() => new(this);
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests.Add(request.RequestUri!);
+
+        if (!_responses.TryGetValue(request.RequestUri!.ToString(), out var response))
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        return Task.FromResult(new HttpResponseMessage(response.Status)
+        {
+            Content = new StringContent(response.Body, Encoding.UTF8, "application/json")
+        });
+    }
+}

--- a/Source/Tests/Meadow.SoftwareManager.Unit.Tests/Usings.cs
+++ b/Source/Tests/Meadow.SoftwareManager.Unit.Tests/Usings.cs
@@ -1,6 +1,5 @@
-global using FakeItEasy;
-global using Meadow.Cloud.Client;
-global using Meadow.Cloud.Client.Firmware;
+global using Meadow.SoftwareManager.Unit.Tests;
 global using Meadow.Software;
 global using System.Net;
+global using System.Net.Http;
 global using Xunit;


### PR DESCRIPTION
## Summary

`meadow firmware download` and `meadow firmware list` routed every request through the Meadow.Cloud firmware API. `https://www.meadowcloud.co` now serves an Azure edge "Page not found" page with a `*.azureedge.net` certificate, so both commands failed with `The SSL connection could not be established` regardless of whether the user was logged in.

The firmware metadata and packages never left the public, unauthenticated S3 bucket the original CLI used, so this points the download manager back there. No Meadow.Cloud account, login, or API key is involved in firmware download any more.

## Changes

- `F7FirmwareDownloadManager` fetches `latest.json` / `{version}.json` and the OS + coprocessor zips from `https://s3-us-west-2.amazonaws.com/downloads.wildernesslabs.co/Meadow_Beta/` with a plain `HttpClient`. 404/403 mean "not available"; other failures throw `HttpRequestException`. The source URL and client are constructor-injectable.
- `F7FirmwarePackageCollection` and `FileManager` no longer take `IMeadowCloudClient`.
- `Meadow.SoftwareManager` drops its `Meadow.Cloud.Client` project reference. `Meadow.Tooling.Core`, which uses the cloud client directly, now references it explicitly instead of transitively.
- `FirmwareDownloadCommand` derives from `BaseCommand` instead of `BaseCloudCommand`, so it no longer exposes `--host` / `--apikey` or needs the `RequiresAuthentication` opt-out.
- Unit tests use a stub `HttpMessageHandler` instead of a faked cloud client, and add coverage for URL building, forbidden, and empty-version responses.
- Bump to 3.0.0-beta4.

## Verification

- `Meadow.SoftwareManager.Unit.Tests`: 18 passed.
- Built and installed the tool locally, then against the real bucket: `firmware list` succeeds, `firmware download -v 3.0.0.0` reports the local copy, and `firmware download -v 2.5.5.0` downloads and extracts both zips.

## Notes

- The bucket's `latest.json` still points at 2.5.2.1, so a bare `meadow firmware download` will fetch that and set it as default. Pass `-v` explicitly until that file is updated.
- Other `BaseCloudCommand` commands (device provision, cloud packages, etc.) still target the dead host and are unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zMZJDBbUcXDXvoz1Z7Uai
